### PR TITLE
Polish iPad controls and input defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 <p align="center">
   <strong>Ocarina of Time on iPad, through Ship of Harkinian.</strong><br>
-  Native Metal rendering, on-device setup, touch controls, and
-  physical-controller support—with a clear path for a separate Majora's Mask port.
+  Native Metal rendering, on-device setup, touch, keyboard, mouse, and
+  controller input—with a clear path for a separate Majora's Mask port.
 </p>
 
 <p align="center">
   <a href="docs/remaining-work.md"><img alt="arm64 iOS build verified" src="https://img.shields.io/badge/build-arm64%20iOS-30D158"></a>
   <img alt="iOS 14+" src="https://img.shields.io/badge/iOS-14%2B-0A84FF?logo=apple">
   <img alt="Metal renderer" src="https://img.shields.io/badge/renderer-Metal-5E5CE6">
-  <img alt="Touch and controller input" src="https://img.shields.io/badge/input-touch%20%2B%20controller-30D158">
+  <img alt="Touch, keyboard, mouse, and controller input" src="https://img.shields.io/badge/input-touch%20%2B%20keyboard%20%2B%20controller-30D158">
   <img alt="ROM not included" src="https://img.shields.io/badge/game%20data-not%20included-FF9F0A">
 </p>
 
@@ -21,7 +21,7 @@ HarkinianPad brings the complete
 to Apple mobile devices. It runs through SDL's UIKit entry point, renders
 through Metal, discovers a user-provided ROM through Files, performs extraction
 inside the app container, and offers a grip-first N64 touch layout alongside
-iOS-compatible game controllers.
+keyboard, trackpad/mouse, and iOS-compatible game-controller input.
 
 This repository contains the reproducible iOS integration—not either game.
 HarkinianPad never ships a ROM or the ROM-derived archive needed to play.
@@ -218,7 +218,8 @@ ROMs, ROM-derived `oot*.o2r`/`.otr` files, and prohibited game data inside
 2. In Files, move your supported ROM to **On My iPad → HarkinianPad**.
 3. Return to HarkinianPad and choose **Rescan**.
 4. Leave the app open while it creates the local archive.
-5. Press the on-screen **Start** button, or use a connected controller.
+5. Press the on-screen **Start** button, press **Space** or **Return** on a
+   keyboard, or use a connected controller.
 
 The original ROM and generated `oot.o2r` remain local. They are ignored by
 Git, excluded from CI, and rejected by the package audit.
@@ -226,12 +227,17 @@ Git, excluded from CI, and rejected by the package audit.
 ## Controls
 
 The overlay is designed around the lower half of a landscape iPad so both
-hands can remain on the side edges:
+hands can remain on the side edges. Its shoulder, face/D-pad, and stick/C
+groups occupy three distinct bands rather than competing for the same thumb
+space:
 
 - **Left:** L/Z shoulder row, separate D-pad, and a low eight-way control stick.
 - **Right:** Start/R shoulder row, A/B/Z cluster, Menu, and a separate low
   C-button diamond.
-- **Toggle:** open **☰ → Settings → Controls → Touch Controls**.
+- **Menus:** opening **☰** hides the gameplay controls so settings remain
+  unobstructed; closing the menu restores them automatically.
+- **Toggle:** use **Settings → Controls → Touch Controls** to disable or
+  re-enable the overlay entirely.
 
 | Touch control | Existing Shipwright binding |
 |---|---|
@@ -239,7 +245,7 @@ hands can remain on the side edges:
 | D-pad | T/G/F/H |
 | A / B | X / C |
 | L / Z / R | E / Z / R |
-| Start | Space |
+| Start | Space or Return |
 | C buttons | Arrow keys |
 | Menu | Escape |
 
@@ -247,6 +253,20 @@ The touch stick is intentionally a simple eight-way testing control. A
 physical controller remains the reference path for analog precision. The full
 layout and acceptance contract are in
 [`docs/touch-controls-design.md`](docs/touch-controls-design.md).
+
+Keyboard, trackpad/mouse, and controller input use Shipwright's native input
+system:
+
+- **Keyboard:** W/A/S/D moves, X is A, C is B, Z is Z, Space or Return is
+  Start, arrow keys are C buttons, and Escape opens the menu.
+- **Trackpad or mouse:** primary click is A, secondary click is B, and middle
+  click is Z. Pair it with the keyboard for movement.
+- **Controller:** the left stick, face buttons, triggers/shoulders, Start,
+  D-pad, and right stick retain Shipwright's SDL game-controller mappings.
+
+These defaults apply automatically to a clean configuration. On an existing
+installation, choose **Set Defaults** for Keyboard or Mouse in
+**Settings → Controls** to add the new defaults without rebuilding.
 
 ## Frequently asked questions
 
@@ -310,11 +330,11 @@ when the overlay is removed.
 </details>
 
 <details>
-<summary><strong>Why does Enter do nothing at the title screen?</strong></summary>
+<summary><strong>Do Space and Return both work as Start?</strong></summary>
 
-Start uses Shipwright's existing **Space** binding. The built-in touch layout
-exposes a dedicated Start button, so no keyboard is required for basic
-Simulator navigation.
+Yes. Both are included in the current default keyboard mapping. If the app
+already has an older controller configuration, choose **Set Defaults** for
+Keyboard under **Settings → Controls** once.
 </details>
 
 <details>

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -122,7 +122,8 @@ L/Z, a separate four-button D-pad, and a low control stick. The right rail has
 Start/R, an A/B/Z cluster, a menu button, and a separate low four-button
 C diamond. The duplicated Z control keeps the trigger reachable from either
 grip. Empty overlay space passes through to the game and menus. Open the menu
-with **☰**, then turn the overlay off or back on under
+with **☰**; the gameplay overlay disappears while the menu is visible and
+returns when the menu closes. Turn it off or back on entirely under
 **Settings > Controls > Touch Controls**.
 
 The basic touch bridge reuses the existing bindings:
@@ -133,7 +134,7 @@ The basic touch bridge reuses the existing bindings:
 | D-pad | T/G/F/H |
 | A / B | X / C |
 | L / Z (either) / R | E / Z / R |
-| Start | Space |
+| Start | Space or Return |
 | C buttons | Arrow keys |
 | Menu | Escape |
 
@@ -144,6 +145,21 @@ in Settings before launching the app. For a Simulator-only check, connect the
 controller to the Mac and choose **I/O > Input > Send Game Controller to
 Device** in Simulator.
 
+For keyboard and pointing-device testing, the default mappings are:
+
+| Device input | N64 action |
+|---|---|
+| W/A/S/D | Control stick |
+| X / C / Z | A / B / Z |
+| Space or Return | Start |
+| Arrow keys | C buttons |
+| Primary / secondary / middle click | A / B / Z |
+
+On an installation that already wrote an older controller configuration,
+expand Keyboard or Mouse under **Settings > Controls** and choose
+**Set Defaults** once. Trackpad/mouse input complements the keyboard; it does
+not replace movement input.
+
 At the title screen, test the touch layout and then the controller separately.
 Confirm that:
 
@@ -152,11 +168,13 @@ Confirm that:
    input viewer.
 2. Disabling **Touch Controls** removes the overlay immediately; enabling it
    restores the overlay without restarting.
-3. A save can be created or selected and Link can be controlled in active
+3. Opening the menu hides every gameplay control, and closing it restores the
+   overlay only when **Touch Controls** is enabled.
+4. A save can be created or selected and Link can be controlled in active
    gameplay for at least ten minutes.
-4. Disconnecting and reconnecting the controller does not crash the app and
+5. Disconnecting and reconnecting the controller does not crash the app and
    restores control without losing the current save.
-5. Rumble and motion input are recorded as supported, unsupported, or not
+6. Rumble and motion input are recorded as supported, unsupported, or not
    exposed for the exact controller model; do not infer either capability
    from the extended-gamepad declaration.
 
@@ -165,9 +183,8 @@ each observed result in [`remaining-work.md`](remaining-work.md). A controller
 forwarded through Simulator is useful diagnostic evidence, but only the
 physical-device replay closes the M4 acceptance gate.
 
-Enter is not Start. The touch layout deliberately posts the bindings above
-through SDL; a desktop keyboard remains diagnostic input rather than a
-substitute for the physical-controller acceptance test.
+Keyboard and pointing-device input remain diagnostic conveniences rather than
+substitutes for the physical-controller acceptance test.
 
 ## Required device acceptance checks
 

--- a/docs/remaining-work.md
+++ b/docs/remaining-work.md
@@ -85,6 +85,41 @@ Simulator evidence as physical-device proof.
 
 ## Evidence log
 
+### 2026-07-26 — Touch spacing and external input defaults passed in Simulator
+
+- Expected: bring the reference-driven controls into comfortable iPad thumb
+  reach, reduce C-button crowding, and make keyboard/trackpad testing useful
+  without adding a second input system.
+- Visual audit and implementation: a live iPad Pro 11-inch (M4), iOS 18.5
+  capture was compared beside the supplied reference. The final layout uses
+  three distinct vertical bands: shoulders near 38% height, D-pad and A/B/Z
+  near 60%, and the stick/C diamond near 86%. C buttons are 54 points at base
+  scale, below the 72-point A/B controls; the menu is 50 points. Blue A, green
+  B, red Start, and amber C controls make the groups legible without adding
+  textures or decoration.
+- Input implementation: the existing SDL keyboard defaults now accept both
+  Space and Return for Start. On iOS, the existing mouse mapping system gains
+  primary click for A, secondary click for B, and middle click for Z. The SDL
+  game-controller path is unchanged.
+- Build/runtime evidence: the complete arm64 Simulator build succeeded, then
+  an incremental Release build compiled the final Objective-C++ layout and
+  linked/codesigned `HarkinianPad.app`. The latest app was reinstalled and
+  launched on the same Simulator. The complete overlay rendered without
+  overlaps. The live Menu button opened Controls with all gameplay controls
+  removed; closing the menu restored the complete overlay. The Touch Controls
+  setting also removed and restored the overlay without restart.
+- Device/package evidence: `scripts/build-ios.sh --device` replayed all five
+  maintained patches, and the final arm64 iPhoneOS build compiled the changed
+  keyboard, mouse, menu-lifecycle, and touch sources with `BUILD SUCCEEDED`.
+  The package audit produced the ROM-free unsigned proof artifact
+  `artifacts/HarkinianPad-9.2.3-unsigned.ipa`, SHA-256
+  `5eb6f3cff0bf49829a2f53e1b0b78e936203dd697aad6f6f384fdff3fd569ca5`.
+- Boundary: keyboard and mouse defaults apply automatically to clean
+  configurations; an existing installation must choose **Set Defaults** for
+  the relevant device once. No physical controller was available, so real
+  controller input, reconnect, rumble/motion capability, multitouch feel, and
+  signed-device installation remain open hardware gates.
+
 ### 2026-07-25 — Reference-driven low-grip touch controls passed in Simulator
 
 - Expected: make a clean install testable without a paired controller using a
@@ -187,9 +222,9 @@ Simulator evidence as physical-device proof.
   `gamecontrollerdb.txt` retains SHA-256
   `eb002773dc8a16aa96f9ee2609798e231a9deb60c45e21fbdd4e221c9e8b7d77`.
   The live iPad configuration maps SDL controller button 6 to Start, button 0
-  to A, and button 1 to B. Its displayed keyboard fallback is Space for
-  Start, X for A, C for B, and WASD for movement; Enter is not mapped to
-  Start.
+  to A, and button 1 to B. At that checkpoint, its displayed keyboard fallback
+  was Space for Start, X for A, C for B, and WASD for movement. The later
+  2026-07-26 input pass added Return as a second default Start binding.
 - Availability result: a fresh USB/Bluetooth system-profiler query still
   found no connected game controller, so no navigation, gameplay, reconnect,
   rumble, or motion result is claimed.

--- a/docs/touch-controls-design.md
+++ b/docs/touch-controls-design.md
@@ -8,7 +8,7 @@ landscape iPad, while leaving the center of the game readable.
 
 ## Visual reference
 
-The reference supplied on 2026-07-25 establishes four priorities:
+The reference supplied on 2026-07-25 establishes five priorities:
 
 1. The control stick sits low under the left thumb.
 2. The D-pad and control stick remain separate left-side groups.
@@ -28,18 +28,18 @@ ornament.
 │                                                              │
 │  [ L ] [ Z ]                               [Start] [ R ]      │
 │    ( spaced D-pad )                         ( B ) ( Z )        │
-│                                             [menu] ( A )       │
-│      ( control stick )                    ( spaced C diamond ) │
+│                                                 ( A ) [menu]   │
+│      ( control stick )                    ( compact C diamond )│
 └──────────────────────────────────────────────────────────────┘
 ```
 
 - Every control begins in the lower half of a landscape iPad.
-- L/Z and Start/R sit at roughly 43% height, within reach while holding the
+- L/Z and Start/R sit at roughly 38% height, within reach while holding the
   side edges.
-- The spaced D-pad and A/B/Z cluster sit at roughly 62% height.
+- The spaced D-pad and A/B/Z cluster sit at roughly 60% height.
 - The menu toggle stays on the outer-right rail between the face and C groups.
 - The control stick and spaced C-button diamond share a low thumb line at
-  roughly 85% height.
+  roughly 86% height.
 - Z is intentionally duplicated in the left shoulder row and right face
   cluster; both copies emit the same binding.
 - iPhone uses the same relationships at a smaller scale.
@@ -47,9 +47,10 @@ ornament.
 
 ## Input mapping
 
-The first custom layout reuses HarkinianPad's existing keyboard mappings by
-posting SDL key events. This keeps the change inside one iOS bridge and avoids
-modifying libultraship's controller model.
+The touch overlay reuses HarkinianPad's keyboard mappings by posting SDL key
+events. Two small iOS-only defaults make external testing less surprising:
+Return also maps to Start, while primary, secondary, and middle mouse clicks
+map to A, B, and Z.
 
 | Touch element | Existing binding | N64 action |
 |---|---|---|
@@ -60,7 +61,7 @@ modifying libultraship's controller model.
 | L | E | L |
 | Z (left and right) | Z | Z |
 | R | R | R |
-| Start | Space | Start |
+| Start | Space or Return | Start |
 | C up/down/left/right | Arrow keys | C buttons |
 | Menu | Escape | Open/close HarkinianPad menu |
 
@@ -75,12 +76,19 @@ for final gameplay feel.
 - Persist it with the existing CVar configuration.
 - Enabling installs the overlay on the active SDL window.
 - Disabling removes it immediately and releases every held input.
+- Opening the Shipwright menu temporarily removes the gameplay overlay and
+  releases held input; closing the menu restores it only when the persisted
+  Touch Controls setting remains enabled.
 
 ## Styling
 
 - Near-black fill at roughly one-third opacity.
 - Two-point light border with white labels.
 - Circular thumb and face controls; compact pills for shoulders.
+- N64-inspired hierarchy: blue A, green B, red Start, and amber C buttons.
+- Primary A/B buttons are 72 points at base scale; D-pad buttons are 58,
+  C buttons are 54, the menu is 50, and the stick is 150. The smaller
+  secondary controls preserve clear gaps between groups.
 - A brighter fill while pressed.
 - No textures, custom assets, haptics, editor, or resize system.
 
@@ -92,8 +100,13 @@ for final gameplay feel.
    groups in the lower half.
 3. Start advances the title screen and A/B navigate file select.
 4. The stick and C diamond emit the existing directional inputs.
-5. The Controls-menu toggle removes and restores the overlay without restart.
-6. The physical-controller path and ROM-free package audit are unchanged.
+5. Opening the menu hides the complete gameplay overlay; closing it restores
+   the overlay only when Touch Controls remains enabled.
+6. The Controls-menu toggle removes and restores the overlay without restart.
+7. A clean/default keyboard configuration accepts Space and Return for Start.
+8. A clean/default mouse configuration maps primary/secondary/middle click to
+   A/B/Z.
+9. The physical-controller path and ROM-free package audit are unchanged.
 
 Physical-iPad grip, simultaneous multi-touch feel, and obscured-content review
 remain hardware acceptance checks.

--- a/patches/libultraship-ios.patch
+++ b/patches/libultraship-ios.patch
@@ -443,15 +443,16 @@ index eaea3cd7..5bc888a9 100644
              const float textWidth = GetStringWidth(overlay.Value.c_str());
              const float textOffset = 40.0f;
 diff --git a/src/ship/window/gui/Gui.cpp b/src/ship/window/gui/Gui.cpp
-index 1cf50fcc..6b06c69f 100644
+index 1cf50fcc..e3be55cb 100644
 --- a/src/ship/window/gui/Gui.cpp
 +++ b/src/ship/window/gui/Gui.cpp
-@@ -7,6 +7,10 @@
+@@ -7,6 +7,11 @@
  #include <string>
  #include <vector>
  
 +#ifdef __IOS__
 +#include <SDL2/SDL.h>
++extern "C" void HarkinianPad_SetTouchControlsMenuVisible(int visible);
 +#endif
 +
  #include "ship/config/Config.h"
@@ -478,3 +479,66 @@ index 1cf50fcc..6b06c69f 100644
  #endif
  
      mImGuiIniPath = Context::GetPathRelativeToAppDirectory("imgui.ini");
+@@ -239,6 +254,10 @@ void Gui::DrawMenu() {
+         GetMenu()->Draw();
+     }
+ 
++#ifdef __IOS__
++    HarkinianPad_SetTouchControlsMenuVisible(GetMenuOrMenubarVisible());
++#endif
++
+     for (auto& windowIter : mGuiWindows) {
+         windowIter.second->Update();
+         windowIter.second->Draw();
+diff --git a/src/libultraship/controller/controldevice/controller/mapping/ControllerDefaultMappings.cpp b/src/libultraship/controller/controldevice/controller/mapping/ControllerDefaultMappings.cpp
+index c431c346..1bce6004 100644
+--- a/src/libultraship/controller/controldevice/controller/mapping/ControllerDefaultMappings.cpp
++++ b/src/libultraship/controller/controldevice/controller/mapping/ControllerDefaultMappings.cpp
+@@ -51,7 +51,7 @@ void ControllerDefaultMappings::SetDefaultKeyboardKeyToButtonMappings(
+         { BTN_L, { Ship::KbScancode::LUS_KB_E } },
+         { BTN_R, { Ship::KbScancode::LUS_KB_R } },
+         { BTN_Z, { Ship::KbScancode::LUS_KB_Z } },
+-        { BTN_START, { Ship::KbScancode::LUS_KB_SPACE } },
++        { BTN_START, { Ship::KbScancode::LUS_KB_SPACE, Ship::KbScancode::LUS_KB_ENTER } },
+         { BTN_CUP, { Ship::KbScancode::LUS_KB_ARROWKEY_UP } },
+         { BTN_CDOWN, { Ship::KbScancode::LUS_KB_ARROWKEY_DOWN } },
+         { BTN_CLEFT, { Ship::KbScancode::LUS_KB_ARROWKEY_LEFT } },
+diff --git a/src/ship/controller/controldevice/controller/ControllerButton.cpp b/src/ship/controller/controldevice/controller/ControllerButton.cpp
+index eced487d..5a55d5d8 100644
+--- a/src/ship/controller/controldevice/controller/ControllerButton.cpp
++++ b/src/ship/controller/controldevice/controller/ControllerButton.cpp
+@@ -5,6 +5,10 @@
+ #include "ship/controller/controldevice/controller/mapping/keyboard/KeyboardKeyToButtonMapping.h"
+ #include "ship/controller/controldevice/controller/mapping/mouse/MouseButtonToButtonMapping.h"
+ 
++#ifdef __IOS__
++#include "libultraship/libultra/controller.h"
++#endif
++
+ #include "ship/config/ConsoleVariable.h"
+ #include "ship/utils/StringHelper.h"
+ #include <sstream>
+@@ -248,6 +252,23 @@ void ControllerButton::AddDefaultMappings(PhysicalDeviceType physicalDeviceType)
+         }
+     }
+ 
++#ifdef __IOS__
++    if (physicalDeviceType == PhysicalDeviceType::Mouse) {
++        MouseBtn mouseButton = LUS_MOUSE_BTN_UNKNOWN;
++        if (mBitmask == BTN_A) {
++            mouseButton = LUS_MOUSE_BTN_LEFT;
++        } else if (mBitmask == BTN_B) {
++            mouseButton = LUS_MOUSE_BTN_RIGHT;
++        } else if (mBitmask == BTN_Z) {
++            mouseButton = LUS_MOUSE_BTN_MIDDLE;
++        }
++        if (mouseButton != LUS_MOUSE_BTN_UNKNOWN) {
++            AddButtonMapping(
++                std::make_shared<MouseButtonToButtonMapping>(mPortIndex, mBitmask, mouseButton));
++        }
++    }
++#endif
++
+     for (auto [id, mapping] : mButtonMappings) {
+         mapping->SaveToConfig();
+     }

--- a/patches/shipwright-ios-touch-controls.patch
+++ b/patches/shipwright-ios-touch-controls.patch
@@ -12,10 +12,10 @@ index 6e57d8c3d..37602af3a 100644
  # Create source groups that match the real file directory paths
 diff --git a/soh/ios/HarkinianPadTouchControls.h b/soh/ios/HarkinianPadTouchControls.h
 new file mode 100644
-index 000000000..3d83ed847
+index 000000000..30ea1d3e5
 --- /dev/null
 +++ b/soh/ios/HarkinianPadTouchControls.h
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,13 @@
 +#pragma once
 +
 +#ifdef __cplusplus
@@ -24,18 +24,20 @@ index 000000000..3d83ed847
 +
 +int HarkinianPad_TouchControlsAvailable(void);
 +void HarkinianPad_SetTouchControlsEnabled(int enabled);
++void HarkinianPad_SetTouchControlsMenuVisible(int visible);
 +
 +#ifdef __cplusplus
 +}
 +#endif
 diff --git a/soh/ios/HarkinianPadTouchControls.mm b/soh/ios/HarkinianPadTouchControls.mm
 new file mode 100644
-index 000000000..b9e784a26
+index 000000000..684920368
 --- /dev/null
 +++ b/soh/ios/HarkinianPadTouchControls.mm
-@@ -0,0 +1,454 @@
+@@ -0,0 +1,497 @@
 +#import <UIKit/UIKit.h>
 +
++#include <atomic>
 +#include <SDL.h>
 +
 +#include "HarkinianPadTouchControls.h"
@@ -60,10 +62,14 @@ index 000000000..b9e784a26
 +@property(nonatomic) SDL_Scancode scancode;
 +@property(nonatomic) BOOL inputPressed;
 +@property(nonatomic) BOOL usesPillShape;
++@property(nonatomic, strong) UIColor* idleColor;
++@property(nonatomic, strong) UIColor* pressedColor;
 +
 +- (instancetype)initWithLabel:(NSString*)label
 +                     scancode:(SDL_Scancode)scancode
 +                         pill:(BOOL)pill;
++- (void)applyIdleColor:(UIColor*)idleColor
++          pressedColor:(UIColor*)pressedColor;
 +- (void)cancelInput;
 +
 +@end
@@ -78,7 +84,9 @@ index 000000000..b9e784a26
 +        self.scancode = scancode;
 +        self.usesPillShape = pill;
 +        self.multipleTouchEnabled = YES;
-+        self.backgroundColor = [UIColor colorWithWhite:0.04 alpha:0.38];
++        self.idleColor = [UIColor colorWithWhite:0.04 alpha:0.38];
++        self.pressedColor = [UIColor colorWithWhite:0.72 alpha:0.48];
++        self.backgroundColor = self.idleColor;
 +        self.layer.borderColor = [UIColor colorWithWhite:1.0 alpha:0.58].CGColor;
 +        self.layer.borderWidth = 2.0;
 +        [self setTitle:label forState:UIControlStateNormal];
@@ -98,6 +106,13 @@ index 000000000..b9e784a26
 +    return self;
 +}
 +
++- (void)applyIdleColor:(UIColor*)idleColor
++          pressedColor:(UIColor*)pressedColor {
++    self.idleColor = idleColor;
++    self.pressedColor = pressedColor;
++    self.backgroundColor = self.inputPressed ? pressedColor : idleColor;
++}
++
 +- (void)layoutSubviews {
 +    [super layoutSubviews];
 +    self.layer.cornerRadius =
@@ -110,7 +125,7 @@ index 000000000..b9e784a26
 +        return;
 +    }
 +    self.inputPressed = YES;
-+    self.backgroundColor = [UIColor colorWithWhite:0.72 alpha:0.48];
++    self.backgroundColor = self.pressedColor;
 +    HarkinianPad_PushKey(self.scancode, YES);
 +}
 +
@@ -119,7 +134,7 @@ index 000000000..b9e784a26
 +        return;
 +    }
 +    self.inputPressed = NO;
-+    self.backgroundColor = [UIColor colorWithWhite:0.04 alpha:0.38];
++    self.backgroundColor = self.idleColor;
 +    HarkinianPad_PushKey(self.scancode, NO);
 +}
 +
@@ -293,6 +308,24 @@ index 000000000..b9e784a26
 +        self.cRight =
 +            [[HarkinianPadTouchButton alloc] initWithLabel:@"▶" scancode:SDL_SCANCODE_RIGHT pill:NO];
 +
++        [self.buttonA
++            applyIdleColor:[UIColor colorWithRed:0.08 green:0.35 blue:0.88 alpha:0.58]
++              pressedColor:[UIColor colorWithRed:0.14 green:0.48 blue:1.00 alpha:0.88]];
++        [self.buttonB
++            applyIdleColor:[UIColor colorWithRed:0.05 green:0.55 blue:0.24 alpha:0.58]
++              pressedColor:[UIColor colorWithRed:0.10 green:0.76 blue:0.34 alpha:0.88]];
++        [self.buttonStart
++            applyIdleColor:[UIColor colorWithRed:0.68 green:0.12 blue:0.16 alpha:0.52]
++              pressedColor:[UIColor colorWithRed:0.94 green:0.22 blue:0.26 alpha:0.88]];
++        UIColor* cIdle =
++            [UIColor colorWithRed:0.95 green:0.67 blue:0.12 alpha:0.48];
++        UIColor* cPressed =
++            [UIColor colorWithRed:1.00 green:0.78 blue:0.20 alpha:0.86];
++        for (HarkinianPadTouchButton* button in
++             @[ self.cUp, self.cDown, self.cLeft, self.cRight ]) {
++            [button applyIdleColor:cIdle pressedColor:cPressed];
++        }
++
 +        self.buttonStart.accessibilityLabel = @"Start";
 +        self.buttonMenu.accessibilityLabel = @"Menu";
 +        self.buttonZLeft.accessibilityLabel = @"Z left";
@@ -338,11 +371,11 @@ index 000000000..b9e784a26
 +    CGFloat railWidth = MIN(250.0 * scale, usableWidth * 0.22);
 +    CGFloat leftCenter = safe.left + railWidth * 0.5;
 +    CGFloat rightCenter = width - safe.right - railWidth * 0.5;
-+    CGFloat gripTopY = MAX(safe.top + edge, height * 0.43);
-+    CGFloat middleCenterY = height * 0.62;
-+    CGFloat lowCenterY = height * 0.85;
++    CGFloat gripTopY = MAX(safe.top + edge, height * 0.38);
++    CGFloat middleCenterY = height * 0.60;
++    CGFloat lowCenterY = height * 0.86;
 +
-+    CGFloat stickSize = 160.0 * scale;
++    CGFloat stickSize = 150.0 * scale;
 +    self.controlStick.frame =
 +        CGRectMake(leftCenter - stickSize * 0.5, lowCenterY - stickSize * 0.5,
 +                   stickSize, stickSize);
@@ -356,8 +389,8 @@ index 000000000..b9e784a26
 +        CGRectMake(CGRectGetMaxX(self.buttonL.frame) + 10.0 * scale, leftRowY,
 +                   pillHeight, pillHeight);
 +
-+    CGFloat dSize = 64.0 * scale;
-+    CGFloat dRadius = 58.0 * scale;
++    CGFloat dSize = 58.0 * scale;
++    CGFloat dRadius = 54.0 * scale;
 +    CGPoint dCenter = CGPointMake(leftCenter, middleCenterY);
 +    self.dUp.frame =
 +        CGRectMake(dCenter.x - dSize * 0.5,
@@ -372,7 +405,7 @@ index 000000000..b9e784a26
 +        CGRectMake(dCenter.x + dRadius - dSize * 0.5,
 +                   dCenter.y - dSize * 0.5, dSize, dSize);
 +
-+    CGFloat faceSize = 76.0 * scale;
++    CGFloat faceSize = 72.0 * scale;
 +    CGFloat faceCenterY = middleCenterY;
 +    CGFloat faceX = rightCenter - faceSize * 0.5;
 +    self.buttonA.frame =
@@ -384,8 +417,8 @@ index 000000000..b9e784a26
 +        CGRectMake(faceX, faceCenterY - faceSize - 12.0 * scale,
 +                   faceSize, faceSize);
 +
-+    CGFloat cSize = 64.0 * scale;
-+    CGFloat cRadius = 58.0 * scale;
++    CGFloat cSize = 54.0 * scale;
++    CGFloat cRadius = 50.0 * scale;
 +    CGPoint cCenter = CGPointMake(rightCenter, lowCenterY);
 +    self.cUp.frame =
 +        CGRectMake(cCenter.x - cSize * 0.5,
@@ -400,7 +433,7 @@ index 000000000..b9e784a26
 +        CGRectMake(cCenter.x + cRadius - cSize * 0.5,
 +                   cCenter.y - cSize * 0.5, cSize, cSize);
 +
-+    CGFloat menuSize = 58.0 * scale;
++    CGFloat menuSize = 50.0 * scale;
 +    self.buttonMenu.frame =
 +        CGRectMake(width - right - menuSize, height * 0.72 - menuSize * 0.5,
 +                   menuSize, menuSize);
@@ -434,6 +467,7 @@ index 000000000..b9e784a26
 +
 +static HarkinianPadTouchOverlay* sTouchOverlay;
 +static BOOL sTouchControlsDesired;
++static std::atomic_bool sTouchControlsMenuVisible(false);
 +
 +static UIWindow* HarkinianPad_ActiveWindow(void) {
 +    for (UIScene* scene in UIApplication.sharedApplication.connectedScenes) {
@@ -450,7 +484,7 @@ index 000000000..b9e784a26
 +}
 +
 +static void HarkinianPad_ApplyTouchControlsState(void) {
-+    if (!sTouchControlsDesired) {
++    if (!sTouchControlsDesired || sTouchControlsMenuVisible.load()) {
 +        [sTouchOverlay cancelAllInputs];
 +        [sTouchOverlay removeFromSuperview];
 +        sTouchOverlay = nil;
@@ -485,6 +519,16 @@ index 000000000..b9e784a26
 +void HarkinianPad_SetTouchControlsEnabled(int enabled) {
 +    dispatch_async(dispatch_get_main_queue(), ^{
 +        sTouchControlsDesired = enabled != 0;
++        HarkinianPad_ApplyTouchControlsState();
++    });
++}
++
++void HarkinianPad_SetTouchControlsMenuVisible(int visible) {
++    const bool menuVisible = visible != 0;
++    if (sTouchControlsMenuVisible.exchange(menuVisible) == menuVisible) {
++        return;
++    }
++    dispatch_async(dispatch_get_main_queue(), ^{
 +        HarkinianPad_ApplyTouchControlsState();
 +    });
 +}


### PR DESCRIPTION
## What changed

- reshaped the landscape iPad touch layout into three reachable bands with smaller, separated C and D-pad controls
- added N64-inspired color hierarchy for A, B, Start, and C buttons
- automatically hides gameplay controls while the Shipwright menu is visible and restores them when the menu closes
- accepts Return as a second default Start key and adds primary/secondary/middle mouse defaults for A/B/Z
- updates the public README, build guide, touch-design contract, and evidence ledger

## Why

The previous overlay crowded controls together and obscured the settings menu. This keeps the implementation small while making touch testing, menu use, and external keyboard/trackpad testing practical on iPad.

## Validation

- arm64 iPad Simulator Release build: passed
- live iPad Pro 11-inch (M4), iOS 18.5: menu opens with gameplay controls hidden; closing restores the full overlay
- touch setting removes and restores the overlay without restart
- arm64 iPhoneOS unsigned Release build: passed
- maintained source patches reverse-apply cleanly
- ROM-free package audit: passed
- unsigned IPA SHA-256: `5eb6f3cff0bf49829a2f53e1b0b78e936203dd697aad6f6f384fdff3fd569ca5`

## Hardware boundary

Signed installation, physical grip/multitouch feel, and a real Bluetooth/USB controller replay remain physical-iPad acceptance gates.
