### PR TITLE
Fix iPhone display and touch controls

### DIFF
--- a/docs/touch-controls-design.md
+++ b/docs/touch-controls-design.md
@@ -36,16 +36,21 @@ ornament.
 - Gameplay controls stay in the lower half of a landscape iPad.
 - L/Z and Start/R sit below the menu content line, within reach while holding
   the side edges.
-- The compact D-pad sits left of the raised control stick.
-- A/B/Z form a separate right-side triangle; the smaller C-button diamond sits
-  directly below it.
+- The compact D-pad sits left of the raised control stick. On iPhone, the
+  D-pad and C-button rows sit slightly above the face cluster so adjacent
+  controls do not intersect.
+- A/B/Z form a separate right-side triangle. The smaller C-button diamond sits
+  below it on iPad and above it on iPhone so the face buttons occupy the
+  phone's natural lower thumb zone.
 - The persistent `•••` menu button sits at the upper-right safe area on iPad
-  and in a dedicated top-center slot on iPhone. It remains available when
-  gameplay touch controls are disabled.
+  and in a dedicated top-center slot during iPhone gameplay. While the
+  Shipwright menu is open on iPhone, it moves to bottom center so it does not
+  cover the Settings, Enhancements, Randomizer, or Dev Tools tabs. It remains
+  available when gameplay touch controls are disabled.
 - Z is intentionally duplicated in the left shoulder row and right face
   cluster; both copies emit the same binding.
-- iPhone uses a dedicated compact layout with touch targets of at least 44
-  points instead of shrinking the iPad geometry proportionally.
+- iPhone uses a dedicated compact grip layout instead of shrinking the iPad
+  geometry proportionally.
 - Empty overlay space passes touches through to menus, but synthetic
   touch-as-mouse clicks are not forwarded to gameplay button mappings.
 
@@ -96,10 +101,31 @@ the reference for final gameplay feel.
 - N64-inspired hierarchy: blue A, green B, red Start, and amber C buttons.
 - Primary A/B/Z buttons are 66 points at the iPad base scale; D-pad buttons
   are 52, C buttons are 46, the menu is 38, and the stick is 150. The iPhone
-  layout uses 52-point face buttons, 44-point secondary buttons and shoulders,
-  a 44-point menu button, and a 116-point stick.
+  layout uses 52-point face buttons, 44-point D-pad buttons and shoulders,
+  40-point C buttons, a 44-point menu button, and a 116-point stick.
 - A brighter fill while pressed.
 - No textures, custom assets, haptics, editor, or resize system.
+
+## Future native HUD touch experiment
+
+Do not replace the current UIKit controls until a native-HUD prototype passes
+on both iPhone and iPad. Shipwright already supports separate positions for
+the native A, B, and four C-button graphics, but their complete visual scaling
+is not implemented consistently.
+
+The smallest reversible prototype should:
+
+- keep the current UIKit input path and layouts as the fallback;
+- render enlarged native A/B/C graphics over transparent UIKit hit targets
+  during gameplay;
+- restore the visible UIKit buttons whenever the gameplay HUD is unavailable,
+  including title, file-select, pause, and menu states;
+- use separate automatically selected iPhone and iPad position presets; and
+- keep C-up discoverable for normal input while preserving Navi's conditional
+  prompt behavior.
+
+Simulator proof is necessary for layout work, but final acceptance requires
+physical gameplay on both device classes.
 
 ## Acceptance checks
 

--- a/docs/touch-controls-design.md
+++ b/docs/touch-controls-design.md
@@ -39,13 +39,15 @@ ornament.
 - The compact D-pad sits left of the raised control stick.
 - A/B/Z form a separate right-side triangle; the smaller C-button diamond sits
   directly below it.
-- The 38-point persistent `•••` menu button sits at the upper-right safe area,
-  below Shipwright's menu divider. It remains available when gameplay touch
-  controls are disabled.
+- The persistent `•••` menu button sits at the upper-right safe area on iPad
+  and in a dedicated top-center slot on iPhone. It remains available when
+  gameplay touch controls are disabled.
 - Z is intentionally duplicated in the left shoulder row and right face
   cluster; both copies emit the same binding.
-- iPhone uses the same relationships at a smaller scale.
-- Empty overlay space passes touches through to the game and menus.
+- iPhone uses a dedicated compact layout with touch targets of at least 44
+  points instead of shrinking the iPad geometry proportionally.
+- Empty overlay space passes touches through to menus, but synthetic
+  touch-as-mouse clicks are not forwarded to gameplay button mappings.
 
 ## Input mapping
 
@@ -67,9 +69,11 @@ map to A, B, and Z.
 | C up/down/left/right | Arrow keys | C buttons |
 | Menu | Escape | Open/close HarkinianPad menu |
 
-The on-screen stick is deliberately eight-way in this basic test slice.
-Physical controllers retain their normal analog path and remain the reference
-for final gameplay feel.
+The on-screen stick is deliberately eight-way in this basic test slice. It
+uses separate engage/release thresholds to prevent direction chatter, keeps
+smaller deflections cardinal for menu precision, and allows diagonals in the
+outer ring. Physical controllers retain their normal analog path and remain
+the reference for final gameplay feel.
 
 ## Toggle behavior
 
@@ -90,9 +94,10 @@ for final gameplay feel.
 - Two-point light border with white labels.
 - Circular thumb and face controls; compact pills for shoulders.
 - N64-inspired hierarchy: blue A, green B, red Start, and amber C buttons.
-- Primary A/B/Z buttons are 66 points at base scale; D-pad buttons are 52,
-  C buttons are 46, the menu is 38, and the stick is 150. The smaller
-  secondary controls preserve clear gaps between groups.
+- Primary A/B/Z buttons are 66 points at the iPad base scale; D-pad buttons
+  are 52, C buttons are 46, the menu is 38, and the stick is 150. The iPhone
+  layout uses 52-point face buttons, 44-point secondary buttons and shoulders,
+  a 44-point menu button, and a 116-point stick.
 - A brighter fill while pressed.
 - No textures, custom assets, haptics, editor, or resize system.
 
@@ -110,7 +115,9 @@ for final gameplay feel.
 7. A clean/default keyboard configuration accepts Space and Return for Start.
 8. A clean/default mouse configuration maps primary/secondary/middle click to
    A/B/Z.
-9. The physical-controller path and ROM-free package audit are unchanged.
+9. Empty-screen taps do not trigger A, while menu touch and physical mouse
+   input remain available.
+10. The physical-controller path and ROM-free package audit are unchanged.
 
 The core grip layout, navigation, gameplay inputs, menu access, and live toggle
 were accepted on a 12.9-inch iPad Pro (6th generation). Extended simultaneous

--- a/patches/libultraship-ios.patch
+++ b/patches/libultraship-ios.patch
@@ -157,6 +157,16 @@ diff --git a/src/fast/Fast3dWindow.cpp b/src/fast/Fast3dWindow.cpp
 index 2b77a5f2..4e71d61d 100644
 --- a/src/fast/Fast3dWindow.cpp
 +++ b/src/fast/Fast3dWindow.cpp
+@@ -85,3 +85,9 @@ void Fast3dWindow::Init() {
+     isFullscreen =
+         Ship::Context::GetRawInstance()->GetConfig()->GetBool("Window.Fullscreen.Enabled", false) || gameMode;
++#ifdef __IOS__
++    // UIKit already owns the full-screen window. Desktop SDL fullscreen modes
++    // can leave the Metal view black or constrained to a stale saved size.
++    isFullscreen = false;
++    Ship::Context::GetRawInstance()->GetConfig()->SetBool("Window.Fullscreen.Enabled", false);
++#endif
+     posX = Ship::Context::GetRawInstance()->GetConfig()->GetInt("Window.PositionX", 100);
 @@ -126,10 +126,18 @@ void Fast3dWindow::SetMaximumFrameLatency(int32_t latency) {
  }
  
@@ -218,7 +228,20 @@ index 15c5415f..99cb4332 100644
  const SDL_Scancode lus_to_sdl_table[] = {
      SDL_SCANCODE_UNKNOWN,
      SDL_SCANCODE_ESCAPE,
-@@ -235,7 +252,7 @@ void GfxWindowBackendSDL2::SetFullscreenImpl(bool on, bool call_callback) {
+@@ -217,2 +241,12 @@ GfxWindowBackendSDL2::~GfxWindowBackendSDL2() {
+ void GfxWindowBackendSDL2::SetFullscreenImpl(bool on, bool call_callback) {
++#ifdef __IOS__
++    // An iOS application window is already full-screen. Switching SDL desktop
++    // display modes can detach or invalidate the Metal drawable.
++    mFullScreen = false;
++    if (mOnFullscreenChanged != nullptr && call_callback) {
++        mOnFullscreenChanged(false);
++    }
++    return;
++#endif
++
+     if (mFullScreen == on) {
+@@ -235,7 +269,7 @@ void GfxWindowBackendSDL2::SetFullscreenImpl(bool on, bool call_callback) {
          }
      }
  
@@ -227,7 +250,37 @@ index 15c5415f..99cb4332 100644
      // Implement fullscreening with native macOS APIs
      if (on != isNativeMacOSFullscreenActive(mWnd)) {
          toggleNativeMacOSFullscreen(mWnd);
-@@ -657,6 +674,29 @@ void GfxWindowBackendSDL2::HandleSingleEvent(SDL_Event& event) {
+@@ -436,2 +470,9 @@ void GfxWindowBackendSDL2::Init(const char* gameName, const char* gfxApiName, bo
+         SDL_GetRendererOutputSize(mRenderer, &mWindowWidth, &mWindowHeight);
++#ifdef __IOS__
++        int windowWidth = 0;
++        int windowHeight = 0;
++        SDL_GetWindowSize(mWnd, &windowWidth, &windowHeight);
++        SPDLOG_INFO("iOS display initialized: window {}x{}, drawable {}x{}", windowWidth, windowHeight, mWindowWidth,
++                    mWindowHeight);
++#endif
+         window_impl.Metal = { mWnd, mRenderer };
+@@ -626,9 +667,19 @@ void GfxWindowBackendSDL2::HandleSingleEvent(SDL_Event& event) {
+             OnKeyup(event.key.keysym.scancode);
+             break;
+         case SDL_MOUSEBUTTONDOWN:
++#ifdef __IOS__
++            if (event.button.which == SDL_TOUCH_MOUSEID) {
++                break;
++            }
++#endif
+             OnMouseButtonDown(event.button.button - 1);
+             break;
+         case SDL_MOUSEBUTTONUP:
++#ifdef __IOS__
++            if (event.button.which == SDL_TOUCH_MOUSEID) {
++                break;
++            }
++#endif
+             OnMouseButtonUp(event.button.button - 1);
+             break;
+         case SDL_MOUSEWHEEL:
+@@ -657,6 +708,29 @@ void GfxWindowBackendSDL2::HandleSingleEvent(SDL_Event& event) {
          case SDL_DROPFILE:
              Ship::Context::GetRawInstance()->GetFileDropMgr()->SetDroppedFile(event.drop.file);
              break;
@@ -257,7 +310,7 @@ index 15c5415f..99cb4332 100644
          case SDL_QUIT:
              Close();
              break;
-@@ -674,7 +714,7 @@ void GfxWindowBackendSDL2::HandleEvents() {
+@@ -674,7 +748,7 @@ void GfxWindowBackendSDL2::HandleEvents() {
      }
  
      // resync fullscreen state
@@ -266,7 +319,7 @@ index 15c5415f..99cb4332 100644
      auto nextFullscreenState = isNativeMacOSFullscreenActive(mWnd);
      if (mFullScreen != nextFullscreenState) {
          mFullScreen = nextFullscreenState;
-@@ -686,7 +726,11 @@ void GfxWindowBackendSDL2::HandleEvents() {
+@@ -686,7 +760,11 @@ void GfxWindowBackendSDL2::HandleEvents() {
  }
  
  bool GfxWindowBackendSDL2::IsFrameReady() {

--- a/patches/shipwright-ios-touch-controls.patch
+++ b/patches/shipwright-ios-touch-controls.patch
@@ -47,7 +47,7 @@ new file mode 100644
 index 0000000..251faa5
 --- /dev/null
 +++ b/soh/ios/HarkinianPadTouchControls.mm
-@@ -0,0 +1,620 @@
+@@ -0,0 +1,628 @@
 +#import <UIKit/UIKit.h>
 +
 +#include <atomic>
@@ -399,9 +399,9 @@ index 0000000..251faa5
 +    if (compact) {
 +        // A phone needs its own grip layout. Scaling the iPad controls down
 +        // made the face and C buttons smaller than useful touch targets.
-+        CGFloat left = safe.left + 8.0;
-+        CGFloat right = safe.right + 8.0;
-+        CGFloat top = safe.top + 8.0;
++        CGFloat left = safe.left + 10.0;
++        CGFloat right = safe.right + 10.0;
++        CGFloat top = safe.top + 36.0;
 +        CGFloat shoulderHeight = 44.0;
 +        CGFloat shoulderWidth = 76.0;
 +
@@ -416,7 +416,7 @@ index 0000000..251faa5
 +
 +        CGFloat dSize = 44.0;
 +        CGFloat dRadius = 38.0;
-+        CGPoint dCenter = CGPointMake(left + 60.0, top + shoulderHeight + 64.0);
++        CGPoint dCenter = CGPointMake(left + 54.0, top + shoulderHeight + 80.0);
 +        self.dUp.frame =
 +            CGRectMake(dCenter.x - dSize * 0.5, dCenter.y - dRadius - dSize * 0.5, dSize, dSize);
 +        self.dDown.frame =
@@ -428,26 +428,26 @@ index 0000000..251faa5
 +
 +        CGFloat stickSize = 116.0;
 +        CGPoint stickCenter =
-+            CGPointMake(left + 70.0, height - safe.bottom - 64.0);
++            CGPointMake(left + 88.0, height - safe.bottom - 88.0);
 +        self.controlStick.frame =
 +            CGRectMake(stickCenter.x - stickSize * 0.5, stickCenter.y - stickSize * 0.5, stickSize, stickSize);
 +
-+        CGFloat rightCenterX = width - right - 72.0;
-+        CGFloat faceCenterY = top + shoulderHeight + 76.0;
++        CGFloat rightCenterX = width - right - 58.0;
++        CGFloat faceCenterY = height - safe.bottom - 82.0;
 +        CGFloat faceSize = 52.0;
 +        self.buttonA.frame =
-+            CGRectMake(rightCenterX + 24.0 - faceSize * 0.5, faceCenterY + 22.0 - faceSize * 0.5, faceSize,
++            CGRectMake(rightCenterX + 22.0 - faceSize * 0.5, faceCenterY + 18.0 - faceSize * 0.5, faceSize,
 +                       faceSize);
 +        self.buttonB.frame =
-+            CGRectMake(rightCenterX - 34.0 - faceSize * 0.5, faceCenterY + 8.0 - faceSize * 0.5, faceSize,
++            CGRectMake(rightCenterX - 34.0 - faceSize * 0.5, faceCenterY + 2.0 - faceSize * 0.5, faceSize,
 +                       faceSize);
 +        self.buttonZRight.frame =
-+            CGRectMake(rightCenterX + 15.0 - faceSize * 0.5, faceCenterY - 38.0 - faceSize * 0.5, faceSize,
++            CGRectMake(rightCenterX + 12.0 - faceSize * 0.5, faceCenterY - 44.0 - faceSize * 0.5, faceSize,
 +                       faceSize);
 +
-+        CGFloat cSize = 44.0;
-+        CGFloat cRadius = 38.0;
-+        CGPoint cCenter = CGPointMake(rightCenterX, height - safe.bottom - 72.0);
++        CGFloat cSize = 40.0;
++        CGFloat cRadius = 34.0;
++        CGPoint cCenter = CGPointMake(rightCenterX, top + shoulderHeight + 80.0);
 +        self.cUp.frame =
 +            CGRectMake(cCenter.x - cSize * 0.5, cCenter.y - cRadius - cSize * 0.5, cSize, cSize);
 +        self.cDown.frame =
@@ -604,11 +604,19 @@ index 0000000..251faa5
 +    const BOOL compact = height < 560.0;
 +    const CGFloat size = compact ? 44.0 : 38.0;
 +    if (compact) {
++        const BOOL menuVisible = sTouchControlsMenuVisible.load();
++        const CGFloat y =
++            menuVisible ? height - safe.bottom - size - 8.0 : safe.top + 8.0;
 +        sMenuButton.frame =
-+            CGRectMake(CGRectGetMidX(window.bounds) - size * 0.5, safe.top + 8.0, size, size);
++            CGRectMake(CGRectGetMidX(window.bounds) - size * 0.5, y, size, size);
++        sMenuButton.autoresizingMask =
++            UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin |
++            (menuVisible ? UIViewAutoresizingFlexibleTopMargin : UIViewAutoresizingFlexibleBottomMargin);
 +    } else {
 +        sMenuButton.frame =
 +            CGRectMake(CGRectGetWidth(window.bounds) - safe.right - size - 8.0, safe.top + 76.0, size, size);
++        sMenuButton.autoresizingMask =
++            UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleBottomMargin;
 +    }
 +    if (sMenuButton.superview != window) {
 +        [sMenuButton removeFromSuperview];

--- a/patches/shipwright-ios-touch-controls.patch
+++ b/patches/shipwright-ios-touch-controls.patch
@@ -29,12 +29,25 @@ index 000000000..30ea1d3e5
 +#ifdef __cplusplus
 +}
 +#endif
+diff --git a/soh/ios/Info.plist.in b/soh/ios/Info.plist.in
+index e7649651c..13632fa0e 100644
+--- a/soh/ios/Info.plist.in
++++ b/soh/ios/Info.plist.in
+@@ -43,6 +43,8 @@
+     <true/>
+     <key>UIFileSharingEnabled</key>
+     <true/>
++    <key>UILaunchScreen</key>
++    <dict/>
+     <key>UIRequiredDeviceCapabilities</key>
+     <array>
+         <string>arm64</string>
 diff --git a/soh/ios/HarkinianPadTouchControls.mm b/soh/ios/HarkinianPadTouchControls.mm
 new file mode 100644
 index 0000000..251faa5
 --- /dev/null
 +++ b/soh/ios/HarkinianPadTouchControls.mm
-@@ -0,0 +1,530 @@
+@@ -0,0 +1,620 @@
 +#import <UIKit/UIKit.h>
 +
 +#include <atomic>
@@ -208,11 +221,33 @@ index 0000000..251faa5
 +    }
 +    self.knob.center = CGPointMake(center.x + dx, center.y + dy);
 +
-+    CGFloat threshold = radius * 0.30;
-+    [self setScancode:SDL_SCANCODE_W pressed:dy < -threshold state:&_upPressed];
-+    [self setScancode:SDL_SCANCODE_S pressed:dy > threshold state:&_downPressed];
-+    [self setScancode:SDL_SCANCODE_A pressed:dx < -threshold state:&_leftPressed];
-+    [self setScancode:SDL_SCANCODE_D pressed:dx > threshold state:&_rightPressed];
++    // Use separate engage/release thresholds so a thumb near the boundary
++    // does not chatter between directions. Keep smaller deflections cardinal
++    // for precise menu and name-entry navigation; the outer ring allows
++    // normal diagonal movement.
++    CGFloat engageThreshold = radius * 0.46;
++    CGFloat releaseThreshold = radius * 0.28;
++    CGFloat horizontalThreshold = (self.leftPressed || self.rightPressed) ? releaseThreshold : engageThreshold;
++    CGFloat verticalThreshold = (self.upPressed || self.downPressed) ? releaseThreshold : engageThreshold;
++    BOOL pressUp = dy < -verticalThreshold;
++    BOOL pressDown = dy > verticalThreshold;
++    BOOL pressLeft = dx < -horizontalThreshold;
++    BOOL pressRight = dx > horizontalThreshold;
++
++    if (distance < radius * 0.78) {
++        if (fabs(dx) >= fabs(dy)) {
++            pressUp = NO;
++            pressDown = NO;
++        } else {
++            pressLeft = NO;
++            pressRight = NO;
++        }
++    }
++
++    [self setScancode:SDL_SCANCODE_W pressed:pressUp state:&_upPressed];
++    [self setScancode:SDL_SCANCODE_S pressed:pressDown state:&_downPressed];
++    [self setScancode:SDL_SCANCODE_A pressed:pressLeft state:&_leftPressed];
++    [self setScancode:SDL_SCANCODE_D pressed:pressRight state:&_rightPressed];
 +}
 +
 +- (void)touchesBegan:(NSSet<UITouch*>*)touches withEvent:(UIEvent*)event {
@@ -359,23 +394,87 @@ index 0000000..251faa5
 +    UIEdgeInsets safe = self.safeAreaInsets;
 +    CGFloat width = CGRectGetWidth(self.bounds);
 +    CGFloat height = CGRectGetHeight(self.bounds);
-+    // Phones in landscape are roughly half an iPad's height, so the old 0.78
-+    // floor forced iPad-sized controls onto a ~430pt canvas and the clusters
-+    // collided. Let compact heights scale down proportionally.
 +    BOOL compact = height < 560.0;
-+    CGFloat scale = MAX(compact ? 0.44 : 0.78, MIN(1.12, height / 834.0));
++
++    if (compact) {
++        // A phone needs its own grip layout. Scaling the iPad controls down
++        // made the face and C buttons smaller than useful touch targets.
++        CGFloat left = safe.left + 8.0;
++        CGFloat right = safe.right + 8.0;
++        CGFloat top = safe.top + 8.0;
++        CGFloat shoulderHeight = 44.0;
++        CGFloat shoulderWidth = 76.0;
++
++        self.buttonL.frame = CGRectMake(left, top, shoulderWidth, shoulderHeight);
++        self.buttonZLeft.frame =
++            CGRectMake(CGRectGetMaxX(self.buttonL.frame) + 8.0, top, shoulderHeight, shoulderHeight);
++        self.buttonR.frame =
++            CGRectMake(width - right - shoulderWidth, top, shoulderWidth, shoulderHeight);
++        self.buttonStart.frame =
++            CGRectMake(CGRectGetMinX(self.buttonR.frame) - shoulderHeight - 8.0, top, shoulderHeight,
++                       shoulderHeight);
++
++        CGFloat dSize = 44.0;
++        CGFloat dRadius = 38.0;
++        CGPoint dCenter = CGPointMake(left + 60.0, top + shoulderHeight + 64.0);
++        self.dUp.frame =
++            CGRectMake(dCenter.x - dSize * 0.5, dCenter.y - dRadius - dSize * 0.5, dSize, dSize);
++        self.dDown.frame =
++            CGRectMake(dCenter.x - dSize * 0.5, dCenter.y + dRadius - dSize * 0.5, dSize, dSize);
++        self.dLeft.frame =
++            CGRectMake(dCenter.x - dRadius - dSize * 0.5, dCenter.y - dSize * 0.5, dSize, dSize);
++        self.dRight.frame =
++            CGRectMake(dCenter.x + dRadius - dSize * 0.5, dCenter.y - dSize * 0.5, dSize, dSize);
++
++        CGFloat stickSize = 116.0;
++        CGPoint stickCenter =
++            CGPointMake(left + 70.0, height - safe.bottom - 64.0);
++        self.controlStick.frame =
++            CGRectMake(stickCenter.x - stickSize * 0.5, stickCenter.y - stickSize * 0.5, stickSize, stickSize);
++
++        CGFloat rightCenterX = width - right - 72.0;
++        CGFloat faceCenterY = top + shoulderHeight + 76.0;
++        CGFloat faceSize = 52.0;
++        self.buttonA.frame =
++            CGRectMake(rightCenterX + 24.0 - faceSize * 0.5, faceCenterY + 22.0 - faceSize * 0.5, faceSize,
++                       faceSize);
++        self.buttonB.frame =
++            CGRectMake(rightCenterX - 34.0 - faceSize * 0.5, faceCenterY + 8.0 - faceSize * 0.5, faceSize,
++                       faceSize);
++        self.buttonZRight.frame =
++            CGRectMake(rightCenterX + 15.0 - faceSize * 0.5, faceCenterY - 38.0 - faceSize * 0.5, faceSize,
++                       faceSize);
++
++        CGFloat cSize = 44.0;
++        CGFloat cRadius = 38.0;
++        CGPoint cCenter = CGPointMake(rightCenterX, height - safe.bottom - 72.0);
++        self.cUp.frame =
++            CGRectMake(cCenter.x - cSize * 0.5, cCenter.y - cRadius - cSize * 0.5, cSize, cSize);
++        self.cDown.frame =
++            CGRectMake(cCenter.x - cSize * 0.5, cCenter.y + cRadius - cSize * 0.5, cSize, cSize);
++        self.cLeft.frame =
++            CGRectMake(cCenter.x - cRadius - cSize * 0.5, cCenter.y - cSize * 0.5, cSize, cSize);
++        self.cRight.frame =
++            CGRectMake(cCenter.x + cRadius - cSize * 0.5, cCenter.y - cSize * 0.5, cSize, cSize);
++
++        for (HarkinianPadTouchButton* button in self.buttons) {
++            button.titleLabel.font = [UIFont systemFontOfSize:15.0 weight:UIFontWeightSemibold];
++        }
++        self.buttonStart.titleLabel.font = [UIFont systemFontOfSize:15.0 weight:UIFontWeightBold];
++        return;
++    }
++
++    CGFloat scale = MAX(0.78, MIN(1.12, height / 834.0));
 +    CGFloat edge = 18.0 * scale;
 +    CGFloat left = safe.left + edge;
 +    CGFloat right = safe.right + edge;
 +    CGFloat usableWidth = width - safe.left - safe.right;
-+    CGFloat railWidth = MIN(250.0 * scale, usableWidth * (compact ? 0.16 : 0.22));
++    CGFloat railWidth = MIN(250.0 * scale, usableWidth * 0.22);
 +    CGFloat leftCenter = safe.left + railWidth * 0.5;
 +    CGFloat rightCenter = width - safe.right - railWidth * 0.5;
-+    // Compact screens need the three rows pushed apart; the iPad fractions
-+    // bunch the shoulder row, d-pad and stick into the same band.
-+    CGFloat gripTopY = MAX(safe.top + edge, height * (compact ? 0.20 : 0.38));
-+    CGFloat middleCenterY = height * (compact ? 0.54 : 0.60);
-+    CGFloat lowCenterY = height * (compact ? 0.88 : 0.86);
++    CGFloat gripTopY = MAX(safe.top + edge, height * 0.38);
++    CGFloat middleCenterY = height * 0.60;
++    CGFloat lowCenterY = height * 0.86;
 +    CGFloat stickCenterX = leftCenter + 65.0 * scale;
 +    CGFloat stickCenterY = lowCenterY - 70.0 * scale;
 +    CGFloat dpadCenterX = leftCenter - 30.0 * scale;
@@ -500,13 +599,17 @@ index 0000000..251faa5
 +            UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleBottomMargin;
 +    }
 +
-+    const CGFloat size = 38.0;
 +    const UIEdgeInsets safe = window.safeAreaInsets;
 +    const CGFloat height = CGRectGetHeight(window.bounds);
 +    const BOOL compact = height < 560.0;
-+    sMenuButton.frame =
-+        CGRectMake(CGRectGetWidth(window.bounds) - safe.right - size - 8.0,
-+                   safe.top + (compact ? 18.0 : 76.0), size, size);
++    const CGFloat size = compact ? 44.0 : 38.0;
++    if (compact) {
++        sMenuButton.frame =
++            CGRectMake(CGRectGetMidX(window.bounds) - size * 0.5, safe.top + 8.0, size, size);
++    } else {
++        sMenuButton.frame =
++            CGRectMake(CGRectGetWidth(window.bounds) - safe.right - size - 8.0, safe.top + 76.0, size, size);
++    }
 +    if (sMenuButton.superview != window) {
 +        [sMenuButton removeFromSuperview];
 +        [window addSubview:sMenuButton];
@@ -604,7 +707,20 @@ index 786c17591..bcef4c797 100644
  extern "C" {
  #include "include/z64audio.h"
  #include "variables.h"
-@@ -434,6 +438,21 @@ void SohMenu::AddMenuSettings() {
+@@ -332,10 +336,12 @@ void SohMenu::AddMenuSettings() {
+     path.sidebarName = "Graphics";
+     AddSidebarEntry("Settings", "Graphics", 3);
+     AddWidget(path, "Graphics Options", WIDGET_SEPARATOR_TEXT);
++#ifndef __IOS__
+     AddWidget(path, "Toggle Fullscreen", WIDGET_BUTTON)
+         .RaceDisable(false)
+         .Callback([](WidgetInfo& info) { Ship::Context::GetRawInstance()->GetWindow()->ToggleFullscreen(); })
+         .Options(ButtonOptions().Tooltip("Toggles Fullscreen On/Off."));
++#endif
+     AddWidget(path, "Internal Resolution", WIDGET_CVAR_SLIDER_FLOAT)
+         .CVar(CVAR_INTERNAL_RESOLUTION)
+         .RaceDisable(false)
+@@ -434,6 +440,21 @@ void SohMenu::AddMenuSettings() {
      path.sidebarName = "Controls";
      path.column = SECTION_COLUMN_1;
      AddSidebarEntry("Settings", "Controls", 2);


### PR DESCRIPTION
## Summary

- make iOS use the native full-screen canvas and prevent the in-game fullscreen toggle from producing a black/stale display
- suppress SDL's synthetic touch-as-mouse gameplay clicks while preserving real mouse input
- add a dedicated compact iPhone grip layout, steadier analog-stick/cardinal behavior, and non-overlapping D-pad/C/face controls
- move the iPhone `•••` control to bottom center while the Shipwright menu is open so it does not cover menu tabs
- preserve the accepted iPad layout
- document a deliberately deferred, reversible native-HUD A/B/C touch experiment

## Validation

- repository safety audit passed
- `git diff --check main` passed
- clean Shipwright checkout applied the maintained patch series successfully; generated `HarkinianPadTouchControls.mm` matched the working source byte-for-byte
- signed iPhoneOS Release build passed and its app signature/profile verified
- app installed and launched on the attached iPhone 14 and iPad Pro 12.9-inch (6th generation)
- iPad layout received physical-device acceptance; latest iPhone spacing/menu placement was visually verified in Simulator and the current build was deployed to the phone
- complete Simulator Release build passed
- exact unsigned iPhoneOS CI build passed
- unsigned IPA package/proprietary-file audit passed; `REQUIRE_SIGNED=1` correctly rejected the unsigned artifact
- signed ROM-free package audit passed

## Scope note

The native in-game A/B/C HUD is not being rewired in this PR. The existing UIKit input path remains the stable fallback; the investigation and device-specific acceptance gates are recorded in `docs/touch-controls-design.md`.
