### PR TITLE
Promote customizable touch controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,16 +118,19 @@ are ignored by Git and rejected by the repository's package audit.
 
 ## Touch controls
 
-The controller is arranged for a landscape iPad held at both edges:
+HarkinianPad selects a landscape layout for the current device class:
 
-- **Left:** L and Z, a compact D-pad, and the control stick.
-- **Right:** Start and R, the A/B/Z face cluster, and the C-button diamond.
+- **Left:** a separate D-pad, the control stick, and Z within left-thumb reach.
+- **Right:** Start/R/L, the native A/B/C HUD controls, and their transparent
+  UIKit touch targets.
 - **Menu:** the small `•••` button remains available even when gameplay touch
   controls are disabled.
 - **Toggle:** use **Settings → Controls → Touch Controls** to hide or restore
   the gameplay overlay.
-- **Safety:** Reset requires confirmation instead of restarting immediately.
-
+- **Customize:** choose **Customize Touch Layout** to move, resize, or hide
+  controls in separate phone and tablet layouts.
+- **Fallback:** enable **Legacy Fixed Touch Controls** to use the previous
+  non-customizable UIKit controller.
 Opening the menu hides the gameplay controls so the settings interface remains
 usable. Closing it restores the controls only when Touch Controls is enabled.
 
@@ -298,7 +301,8 @@ redistributable open source without resolving that boundary.
 | [`docs/INSTALL_IPA.md`](docs/INSTALL_IPA.md) | Developer-preview IPA installation with AltStore Classic |
 | [`docs/RELEASE_CHECKLIST.md`](docs/RELEASE_CHECKLIST.md) | Source and IPA publication gates |
 | [`docs/touch-controls-design.md`](docs/touch-controls-design.md) | Touch layout and input contract |
-| [`docs/native-hud-touch-experiment.md`](docs/native-hud-touch-experiment.md) | Opt-in native HUD touch experiment and living test log |
+| [`docs/native-hud-touch-experiment.md`](docs/native-hud-touch-experiment.md) | Native HUD touch implementation history and physical test log |
+| [`docs/customizable-touch-controls.md`](docs/customizable-touch-controls.md) | Default movable/resizable touch controls and legacy fallback |
 | [`docs/remaining-work.md`](docs/remaining-work.md) | Evidence ledger and remaining gates |
 | [`ref/`](ref/) | Ignored local reference area; only its safety README is tracked |
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -167,14 +167,19 @@ with **•••**; the gameplay overlay disappears while the menu is visible an
 returns when the menu closes. Turn it off or back on entirely under
 **Settings > Controls > Touch Controls**.
 
-An opt-in **Native HUD Touch Controls (Experimental)** setting is also
-available while the experiment is under development. It keeps the proven SDL
-input path and the existing automatically selected iPhone and iPad geometry.
-Native A, B, and C artwork uses the same live centers and visible sizes as the
-UIKit buttons it replaces. It defaults to off and must not be treated as the
-default layout until the remaining promotion matrix in
-[`native-hud-touch-experiment.md`](native-hud-touch-experiment.md) is complete.
-The current iPhone and iPad layouts are accepted for opt-in experimental use.
+The default controller keeps the proven SDL input path and uses native A, B,
+and C HUD artwork over transparent UIKit touch targets. Choose **Customize
+Touch Layout** to move, resize, or hide individual controls; phone and tablet
+overrides are stored separately. Holding Z for 0.5 seconds latches it with a
+haptic confirmation so the left thumb can return to the stick. Tap Z again to
+release it.
+
+The accepted physical iPhone and iPad layouts are the built-in defaults.
+Enable **Legacy Fixed Touch Controls** to restore the previous
+non-customizable UIKit controller and disable native HUD artwork and the Z
+latch. See
+[`customizable-touch-controls.md`](customizable-touch-controls.md) for the
+layout and persistence contract.
 
 The basic touch bridge reuses the existing bindings:
 
@@ -218,18 +223,25 @@ Confirm that:
    input viewer.
 2. Disabling **Touch Controls** removes the overlay immediately; enabling it
    restores the overlay without restarting.
-3. With **Native HUD Touch Controls (Experimental)** off, confirm the accepted
-   V1 layout is unchanged. With it on, confirm the native A/B/C graphics move
-   with their touch targets during gameplay—including the compact iPhone
-   arrangement—and the visible V1 buttons return on title, file-select, and
-   pause screens.
+3. Confirm the native A/B/C graphics move with their touch targets during
+   gameplay—including the compact iPhone arrangement—and the visible UIKit
+   buttons return on title, file-select, and pause screens.
 4. Opening the menu hides every gameplay control, and closing it restores the
    overlay only when **Touch Controls** is enabled.
-5. A save can be created or selected and Link can be controlled in active
+5. Open **Customize Touch Layout** and confirm the editor can select, move,
+   resize, hide/show, reset, and save controls without
+   changing the other device class's profile. Confirm the stick cannot be
+   hidden and `•••` returns after Done. In gameplay, hold Z for 0.5 seconds:
+   confirm one haptic pulse, a persistent blue Z fill, simultaneous stick
+   movement while Z remains held, and release on the next Z tap. Also confirm
+   opening the menu or backgrounding the app clears the latch. Enable
+   **Legacy Fixed Touch Controls** and confirm the previous fixed UIKit layout
+   returns and the editor is unavailable.
+6. A save can be created or selected and Link can be controlled in active
    gameplay for at least ten minutes.
-6. Disconnecting and reconnecting the controller does not crash the app and
+7. Disconnecting and reconnecting the controller does not crash the app and
    restores control without losing the current save.
-7. Rumble and motion input are recorded as supported, unsupported, or not
+8. Rumble and motion input are recorded as supported, unsupported, or not
    exposed for the exact controller model; do not infer either capability
    from the extended-gamepad declaration.
 

--- a/docs/customizable-touch-controls.md
+++ b/docs/customizable-touch-controls.md
@@ -1,0 +1,67 @@
+# Customizable touch controls
+
+HarkinianPad uses customizable touch controls by default. The built-in phone
+and tablet layouts are the exact normalized layouts accepted on the physical
+iPhone and iPad on 2026-07-29. **Legacy Fixed Touch Controls** remains
+available under **Settings > Controls** as the non-customizable fallback.
+
+**Customize Touch Layout** closes Settings and opens a native editor over the
+live controls:
+
+- tap a control to select it;
+- drag the selected control to move it;
+- use **Size** to scale it from 70% to 150%;
+- use **Hide/Show** for buttons that are not needed;
+- use **Reset** to restore the accepted defaults for the current device class;
+- use **Done** to save and return to gameplay.
+
+The controller also includes a shared iPhone/iPad Z latch. Hold Z for 0.5 seconds
+to lock it down. A haptic pulse confirms the lock and Z remains filled blue;
+tap Z again to release it. Opening the menu, entering the layout editor,
+enabling the legacy controls, or backgrounding the app releases the latch so
+input cannot remain stuck across a state change.
+
+The control stick cannot be hidden, and the permanent `•••` menu control is
+not editable. Starting the editor releases held input and temporarily disables
+the controls' normal gameplay handlers.
+
+## Persistence and layout rules
+
+Phone and tablet layouts are stored separately in `NSUserDefaults`:
+
+```text
+HarkinianPad.TouchLayout.phone-v1
+HarkinianPad.TouchLayout.tablet-v1
+```
+
+Each profile contains property-list-safe normalized centers, scalar sizes, and
+hidden control IDs. Saved controls are rebuilt from the current accepted
+defaults, then clamped inside the current safe area. Reset removes the current
+profile's overrides rather than replacing the defaults with a copied layout.
+
+The native-HUD renderer consumes the final customized A/B/C centers and sizes.
+Hiding one of those controls also suppresses its native HUD artwork. Native
+artwork is disabled while editing so each UIKit control and its hit target can
+be selected directly.
+
+## Validation status
+
+Promotion evidence on 2026-07-29:
+
+- the arm64 iOS Simulator app compiled and linked;
+- Settings opened the editor on iPhone 17 Pro and iPad Pro 13-inch (M5)
+  Simulators;
+- selection, 70–150% resizing, Hide/Show, protected-stick behavior, Reset,
+  Done, and separate `phone-v1`/`tablet-v1` storage were exercised;
+- the permanent menu disappeared only while editing and returned after Done;
+- patch reverse-application and replay reproduced the tested source.
+
+- the shared Z-latch revision compiled and linked for arm64 Simulator and
+  device targets, passed strict device-signature verification, and was
+  accepted on physical hardware;
+- the accepted saved `phone-v1` and `tablet-v1` profiles were captured before
+  promotion and embedded as the clean-install and Reset defaults.
+
+The current promoted build still requires a final physical iPhone/iPad
+regression pass before publication. Simulator proof does not replace that
+hardware acceptance.

--- a/docs/native-hud-touch-experiment.md
+++ b/docs/native-hud-touch-experiment.md
@@ -1,25 +1,23 @@
-# Native HUD touch experiment
+# Native HUD touch implementation history
 
 ## Status
 
-**Experimental, opt-in, accepted for repository inclusion, and not approved
-as the default.**
+**Promoted into the default customizable touch controller on 2026-07-29.**
 
-The accepted UIKit touch controller remains the default. Enable the prototype
-under **Settings > Controls > Native HUD Touch Controls (Experimental)**.
-**Touch Controls** must also remain enabled.
+The previous fixed UIKit controller remains available through **Settings >
+Controls > Legacy Fixed Touch Controls**. **Touch Controls** must remain
+enabled for either controller.
 
-This document is the living record for the experiment. Update the checkpoint
-and feedback tables whenever a build is tested; do not infer physical-device
-acceptance from Simulator results.
+This document preserves the experiment and physical-test history that led to
+promotion. Do not infer acceptance of a new build from an older checkpoint.
 
 ## Product contract
 
-- Default off. Existing installs and clean installs continue to show V1.
-- Turning the experiment off restores V1 immediately without a restart.
-- Experimental gameplay uses the exact accepted V1 touch geometry on both
-  iPhone and iPad. Enabling the experiment changes artwork, not control
-  placement.
+- Default on as part of the customizable controller.
+- Enabling Legacy Fixed Touch Controls restores the previous UIKit controller
+  immediately without a restart.
+- Gameplay uses the accepted customized touch geometry independently on iPhone
+  and iPad.
 - The clear UIKit hit targets remain fully opaque and interactive while
   posting the existing SDL keyboard bindings. Only their artwork is hidden.
 - Only A, B, C-up, C-down, C-left, and C-right change appearance.
@@ -55,11 +53,11 @@ The implementation is isolated in
 `patches/shipwright-ios-native-hud-touch-experiment.patch`, applied after the
 stable `shipwright-ios-touch-controls.patch`.
 
-## Known experimental limits
+## Known limits
 
 - C-up is visually absent unless the game is displaying Navi's C-up prompt.
-- The experiment adds no new press ring, haptics, layout editor, or user
-  scaling.
+- The native artwork itself adds no new input path; the surrounding
+  customizable controller provides the layout editor and Z-latch haptic.
 - General Shipwright HUD scaling remains incomplete; this experiment does not
   enable or modify that unfinished editor.
 - Simulator results establish layout behavior only. Physical iPhone and iPad
@@ -134,14 +132,9 @@ Add one row per meaningful test session.
 | 2026-07-29 | Tablet lower-cluster lift | iPad Pro 12.9-inch (6th generation) | Gameplay, experimental | The first lower-cluster lift improved the layout; physical thumb testing requested one final small upward nudge for the three non-Navi C buttons and a tiny up-and-right stick adjustment. | Preserve Navi and every other control; apply only the requested micro-adjustment and reinstall in place |
 | 2026-07-29 | Tablet micro-adjustment | iPad Pro 12.9-inch (6th generation) | Gameplay, experimental | User accepted the final physical iPad layout. Together with the accepted physical iPhone layout, the experiment is ready for opt-in, default-off repository inclusion. | Keep the experiment default-off; complete the transition, multi-touch, and controller matrices before considering default promotion |
 
-## Promotion gate
+## Promotion decision
 
-Do not replace V1 or enable this experiment by default until:
-
-1. positioning is accepted on both Simulator device classes;
-2. the same build is played on a physical iPhone and iPad;
-3. title, file/name entry, gameplay, pause, Navi, item/ammo, menu, and
-   multi-touch cases pass;
-4. turning the experiment off is confirmed to restore V1 completely; and
-5. the fixed iPad render scale is accepted with item, ammo, Navi, and action
-   labels in representative gameplay states.
+The user accepted the native HUD geometry and touch behavior on both physical
+device classes and requested promotion on 2026-07-29. The legacy fixed UIKit
+controller remains available for the validation cycle. Each promoted build
+must still be installed and reviewed on both devices before publication.

--- a/docs/touch-controls-design.md
+++ b/docs/touch-controls-design.md
@@ -107,12 +107,11 @@ the reference for final gameplay feel.
 - A brighter fill while pressed.
 - No textures, custom assets, haptics, editor, or resize system.
 
-## Native HUD touch experiment
+## Native HUD touch controls
 
-Do not replace the current UIKit controls until a native-HUD prototype passes
-on both iPhone and iPad. Shipwright already supports separate positions for
-the native A, B, and four C-button graphics, but their complete visual scaling
-is not implemented consistently.
+The native-HUD prototype passed on physical iPhone and iPad and is now part of
+the default customizable controller. Shipwright supports separate positions
+for the native A, B, and four C-button graphics.
 
 The smallest reversible prototype should:
 
@@ -128,10 +127,11 @@ The smallest reversible prototype should:
 - keep C-up discoverable for normal input while preserving Navi's conditional
   prompt behavior.
 
-The first opt-in implementation is tracked in
+The implementation history is tracked in
 [`native-hud-touch-experiment.md`](native-hud-touch-experiment.md). It is
-default-off and leaves this V1 layout unchanged. iPhone and iPad experimental
-gameplay changes only the A/B/C rendering; geometry remains identical to V1.
+paired with transparent UIKit hit targets and the accepted device-specific
+customizable layouts. The prior fixed UIKit controller remains available
+through **Legacy Fixed Touch Controls**.
 
 Simulator proof is necessary for layout work, but final acceptance requires
 physical gameplay on both device classes.

--- a/patches/shipwright-ios-customizable-touch-controls.patch
+++ b/patches/shipwright-ios-customizable-touch-controls.patch
@@ -1,0 +1,917 @@
+diff --git a/soh/ios/HarkinianPadTouchControls.h b/soh/ios/HarkinianPadTouchControls.h
+index 1e7450d6c..493db1607 100644
+--- a/soh/ios/HarkinianPadTouchControls.h
++++ b/soh/ios/HarkinianPadTouchControls.h
+@@ -6,6 +6,8 @@ extern "C" {
+ 
+ int HarkinianPad_TouchControlsAvailable(void);
+ void HarkinianPad_SetTouchControlsEnabled(int enabled);
++void HarkinianPad_SetCustomizableTouchControlsEnabled(int enabled);
++void HarkinianPad_BeginTouchLayoutEditing(void);
+ void HarkinianPad_SetTouchControlsMenuVisible(int visible);
+ 
+ enum {
+diff --git a/soh/ios/HarkinianPadTouchControls.mm b/soh/ios/HarkinianPadTouchControls.mm
+index 18b8ab399..954e06329 100644
+--- a/soh/ios/HarkinianPadTouchControls.mm
++++ b/soh/ios/HarkinianPadTouchControls.mm
+@@ -1,12 +1,16 @@
+ #import <UIKit/UIKit.h>
+ 
++#include <algorithm>
+ #include <atomic>
+ #include <SDL.h>
+ 
+ #include "HarkinianPadTouchControls.h"
+ 
+ static std::atomic_bool sTouchControlsDesired(false);
++static std::atomic_bool sCustomizableTouchControlsDesired(false);
+ static std::atomic_bool sTouchControlsMenuVisible(false);
++static std::atomic_bool sLayoutEditorActive(false);
++static BOOL sLayoutEditorRequested;
+ static std::atomic_bool sNativeHudTouchDesired(false);
+ static std::atomic_bool sNativeHudTouchGameplayActive(false);
+ static std::atomic<float> sNativeHudButtonCenters[HARKINIANPAD_HUD_BUTTON_COUNT][2];
+@@ -31,6 +35,10 @@ static void HarkinianPad_PushKey(SDL_Scancode scancode, BOOL pressed) {
+ 
+ @property(nonatomic) SDL_Scancode scancode;
+ @property(nonatomic) BOOL inputPressed;
++@property(nonatomic) BOOL inputLatched;
++@property(nonatomic) BOOL holdToLatch;
++@property(nonatomic) NSUInteger latchGeneration;
++@property(nonatomic) BOOL layoutEditing;
+ @property(nonatomic) BOOL usesPillShape;
+ @property(nonatomic) BOOL nativeHudArtworkHidden;
+ @property(nonatomic, strong) UIColor* idleColor;
+@@ -70,7 +78,10 @@ static void HarkinianPad_PushKey(SDL_Scancode scancode, BOOL pressed) {
+ 
+         [self addTarget:self
+                       action:@selector(inputDown)
+-            forControlEvents:UIControlEventTouchDown | UIControlEventTouchDragEnter];
++            forControlEvents:UIControlEventTouchDown];
++        [self addTarget:self
++                      action:@selector(inputDragEnter)
++            forControlEvents:UIControlEventTouchDragEnter];
+         [self addTarget:self
+                       action:@selector(inputUp)
+             forControlEvents:UIControlEventTouchUpInside | UIControlEventTouchUpOutside |
+@@ -104,12 +115,28 @@ static void HarkinianPad_PushKey(SDL_Scancode scancode, BOOL pressed) {
+     }
+ 
+     self.layer.opacity = 1.0f;
+-    self.backgroundColor = self.inputPressed ? self.pressedColor : self.idleColor;
+-    self.layer.borderColor = [UIColor colorWithWhite:1.0 alpha:0.58].CGColor;
++    self.backgroundColor =
++        self.inputLatched
++            ? [UIColor colorWithRed:0.22 green:0.58 blue:0.96 alpha:0.92]
++            : (self.inputPressed ? self.pressedColor : self.idleColor);
++    self.layer.borderColor =
++        (self.inputLatched
++             ? [UIColor colorWithRed:0.62 green:0.82 blue:1.0 alpha:1.0]
++             : [UIColor colorWithWhite:1.0 alpha:0.58]).CGColor;
+     [self setTitleColor:[UIColor colorWithWhite:1.0 alpha:0.92]
+                forState:UIControlStateNormal];
+ }
+ 
++- (void)setHoldToLatch:(BOOL)holdToLatch {
++    if (_holdToLatch == holdToLatch) {
++        return;
++    }
++    if (!holdToLatch) {
++        [self cancelInput];
++    }
++    _holdToLatch = holdToLatch;
++}
++
+ - (void)layoutSubviews {
+     [super layoutSubviews];
+     self.layer.cornerRadius =
+@@ -117,17 +144,59 @@ static void HarkinianPad_PushKey(SDL_Scancode scancode, BOOL pressed) {
+                            : MIN(CGRectGetWidth(self.bounds), CGRectGetHeight(self.bounds)) * 0.5;
+ }
+ 
+-- (void)inputDown {
+-    if (self.inputPressed) {
++- (void)beginInput {
++    if (self.layoutEditing || self.inputPressed) {
+         return;
+     }
+     self.inputPressed = YES;
+     [self updateAppearance];
+     HarkinianPad_PushKey(self.scancode, YES);
++    if (self.holdToLatch) {
++        NSUInteger generation = ++self.latchGeneration;
++        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)),
++                       dispatch_get_main_queue(), ^{
++                           if (self.latchGeneration == generation) {
++                               [self latchInput];
++                           }
++                       });
++    }
++}
++
++- (void)inputDown {
++    if (self.layoutEditing) {
++        return;
++    }
++    if (self.inputLatched) {
++        self.inputLatched = NO;
++        self.inputPressed = NO;
++        self.accessibilityValue = nil;
++        [self updateAppearance];
++        HarkinianPad_PushKey(self.scancode, NO);
++        return;
++    }
++    [self beginInput];
++}
++
++- (void)inputDragEnter {
++    if (!self.inputLatched) {
++        [self beginInput];
++    }
++}
++
++- (void)latchInput {
++    if (!self.holdToLatch || self.layoutEditing || !self.inputPressed) {
++        return;
++    }
++    self.inputLatched = YES;
++    self.accessibilityValue = @"Locked";
++    UIImpactFeedbackGenerator* feedback =
++        [[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleMedium];
++    [feedback impactOccurred];
+ }
+ 
+ - (void)inputUp {
+-    if (!self.inputPressed) {
++    self.latchGeneration++;
++    if (self.layoutEditing || self.inputLatched || !self.inputPressed) {
+         return;
+     }
+     self.inputPressed = NO;
+@@ -136,14 +205,26 @@ static void HarkinianPad_PushKey(SDL_Scancode scancode, BOOL pressed) {
+ }
+ 
+ - (void)cancelInput {
+-    [self inputUp];
++    self.latchGeneration++;
++    self.inputLatched = NO;
++    self.accessibilityValue = nil;
++    if (!self.inputPressed) {
++        [self updateAppearance];
++        return;
++    }
++    self.inputPressed = NO;
++    [self updateAppearance];
++    HarkinianPad_PushKey(self.scancode, NO);
+ }
+ 
+ @end
+ 
++static HarkinianPadTouchButton* sMenuButton;
++
+ @interface HarkinianPadTouchStick : UIView
+ 
+ @property(nonatomic, strong) UIView* knob;
++@property(nonatomic) BOOL layoutEditing;
+ @property(nonatomic) BOOL upPressed;
+ @property(nonatomic) BOOL downPressed;
+ @property(nonatomic) BOOL leftPressed;
+@@ -235,6 +316,9 @@ static void HarkinianPad_PushKey(SDL_Scancode scancode, BOOL pressed) {
+ }
+ 
+ - (void)touchesBegan:(NSSet<UITouch*>*)touches withEvent:(UIEvent*)event {
++    if (self.layoutEditing) {
++        return;
++    }
+     UITouch* touch = touches.anyObject;
+     if (touch != nil) {
+         [self updateForPoint:[touch locationInView:self]];
+@@ -242,6 +326,9 @@ static void HarkinianPad_PushKey(SDL_Scancode scancode, BOOL pressed) {
+ }
+ 
+ - (void)touchesMoved:(NSSet<UITouch*>*)touches withEvent:(UIEvent*)event {
++    if (self.layoutEditing) {
++        return;
++    }
+     UITouch* touch = touches.anyObject;
+     if (touch != nil) {
+         [self updateForPoint:[touch locationInView:self]];
+@@ -284,8 +371,29 @@ static void HarkinianPad_PushKey(SDL_Scancode scancode, BOOL pressed) {
+ @property(nonatomic, strong) HarkinianPadTouchButton* cDown;
+ @property(nonatomic, strong) HarkinianPadTouchButton* cLeft;
+ @property(nonatomic, strong) HarkinianPadTouchButton* cRight;
++@property(nonatomic) BOOL customizableControls;
++@property(nonatomic) BOOL layoutEditing;
++@property(nonatomic, strong) NSArray<UIView*>* editableControls;
++@property(nonatomic, strong) NSMutableArray<UIGestureRecognizer*>* editGestures;
++@property(nonatomic, strong) NSMutableDictionary<NSString*, NSArray<NSNumber*>*>* layoutCenters;
++@property(nonatomic, strong) NSMutableDictionary<NSString*, NSNumber*>* layoutScales;
++@property(nonatomic, strong) NSMutableSet<NSString*>* hiddenControls;
++@property(nonatomic, strong) NSMutableDictionary<NSString*, NSValue*>* defaultSizes;
++@property(nonatomic, copy) NSString* layoutProfile;
++@property(nonatomic, strong) UIView* selectedControl;
++@property(nonatomic, strong) UIView* editorPanel;
++@property(nonatomic, strong) UILabel* editorLabel;
++@property(nonatomic, strong) UISlider* sizeSlider;
++@property(nonatomic, strong) UIButton* visibilityButton;
++@property(nonatomic, strong) UIButton* resetButton;
++@property(nonatomic, strong) UIButton* doneButton;
+ 
+ - (void)cancelAllInputs;
++- (void)setCustomizableControlsEnabled:(BOOL)enabled;
++- (void)beginLayoutEditing;
++- (void)endLayoutEditing;
++- (void)installLayoutEditor;
++- (void)finishControlLayoutForCompact:(BOOL)compact;
+ - (void)publishNativeHudButtonCenters;
+ - (void)applyNativeHudVisualState;
+ 
+@@ -353,16 +461,45 @@ static void HarkinianPad_PushKey(SDL_Scancode scancode, BOOL pressed) {
+         self.cLeft.accessibilityLabel = @"C Left";
+         self.cRight.accessibilityLabel = @"C Right";
+ 
++        self.controlStick.accessibilityIdentifier = @"stick";
++        self.buttonA.accessibilityIdentifier = @"a";
++        self.buttonB.accessibilityIdentifier = @"b";
++        self.buttonL.accessibilityIdentifier = @"l";
++        self.buttonZRight.accessibilityIdentifier = @"z";
++        self.buttonR.accessibilityIdentifier = @"r";
++        self.buttonStart.accessibilityIdentifier = @"start";
++        self.dUp.accessibilityIdentifier = @"d-up";
++        self.dDown.accessibilityIdentifier = @"d-down";
++        self.dLeft.accessibilityIdentifier = @"d-left";
++        self.dRight.accessibilityIdentifier = @"d-right";
++        self.cUp.accessibilityIdentifier = @"c-up";
++        self.cDown.accessibilityIdentifier = @"c-down";
++        self.cLeft.accessibilityIdentifier = @"c-left";
++        self.cRight.accessibilityIdentifier = @"c-right";
++
+         self.buttons = @[
+             self.buttonA, self.buttonB, self.buttonL, self.buttonZRight,
+             self.buttonR, self.buttonStart,
+             self.dUp, self.dDown, self.dLeft, self.dRight, self.cUp, self.cDown,
+             self.cLeft, self.cRight,
+         ];
++        self.editableControls = @[
++            self.controlStick, self.buttonA, self.buttonB, self.buttonL,
++            self.buttonZRight, self.buttonR, self.buttonStart,
++            self.dUp, self.dDown, self.dLeft, self.dRight,
++            self.cUp, self.cDown, self.cLeft, self.cRight,
++        ];
++        self.layoutCenters = [NSMutableDictionary dictionary];
++        self.layoutScales = [NSMutableDictionary dictionary];
++        self.hiddenControls = [NSMutableSet set];
++        self.defaultSizes = [NSMutableDictionary dictionary];
++        self.editGestures = [NSMutableArray array];
++
+         [self addSubview:self.controlStick];
+         for (HarkinianPadTouchButton* button in self.buttons) {
+             [self addSubview:button];
+         }
++        [self installLayoutEditor];
+     }
+     return self;
+ }
+@@ -447,6 +584,19 @@ static void HarkinianPad_PushKey(SDL_Scancode scancode, BOOL pressed) {
+             button.titleLabel.font = [UIFont systemFontOfSize:15.0 weight:UIFontWeightSemibold];
+         }
+         self.buttonStart.titleLabel.font = [UIFont systemFontOfSize:15.0 weight:UIFontWeightBold];
++
++        // Promoted from the accepted physical iPhone layout.
++        self.cLeft.center = CGPointMake(width * 0.823855, height * 0.485470);
++        self.dDown.center = CGPointMake(width * 0.130727, height * 0.501709);
++        self.cDown.center = CGPointMake(width * 0.866509, height * 0.570085);
++        self.cUp.center = CGPointMake(width * 0.866904, height * 0.398291);
++        self.controlStick.center = CGPointMake(width * 0.214455, height * 0.722222);
++        self.buttonZRight.center = CGPointMake(width * 0.242496, height * 0.499145);
++        self.buttonA.center = CGPointMake(width * 0.876382, height * 0.737607);
++        self.cRight.center = CGPointMake(width * 0.911137, height * 0.486325);
++        self.buttonB.center = CGPointMake(width * 0.805687, height * 0.664957);
++
++        [self finishControlLayoutForCompact:YES];
+         [self publishNativeHudButtonCenters];
+         [self applyNativeHudVisualState];
+         return;
+@@ -549,10 +699,387 @@ static void HarkinianPad_PushKey(SDL_Scancode scancode, BOOL pressed) {
+     }
+     self.buttonStart.titleLabel.font =
+         [UIFont systemFontOfSize:18.0 * scale weight:UIFontWeightBold];
++
++    // Promoted from the accepted physical iPad layout.
++    self.cLeft.center = CGPointMake(width * 0.856515, height * 0.853922);
++    self.cDown.center = CGPointMake(width * 0.902240, height * 0.905152);
++    self.cUp.center = CGPointMake(width * 0.903338, height * 0.805484);
++    self.controlStick.center = CGPointMake(width * 0.164363, height * 0.745313);
++    self.buttonZRight.center = CGPointMake(width * 0.193089, height * 0.612859);
++    self.buttonA.center = CGPointMake(width * 0.893309, height * 0.693020);
++    self.cRight.center = CGPointMake(width * 0.948331, height * 0.852945);
++    self.buttonB.center = CGPointMake(width * 0.826029, height * 0.635117);
++
++    [self finishControlLayoutForCompact:NO];
+     [self publishNativeHudButtonCenters];
+     [self applyNativeHudVisualState];
+ }
+ 
++- (void)setCustomizableControlsEnabled:(BOOL)enabled {
++    if (self.customizableControls == enabled) {
++        return;
++    }
++    [self cancelAllInputs];
++    self.customizableControls = enabled;
++    self.buttonZRight.holdToLatch = enabled;
++    if (!enabled && self.layoutEditing) {
++        [self endLayoutEditing];
++    }
++    [self setNeedsLayout];
++}
++
++- (UIButton*)editorButtonWithTitle:(NSString*)title action:(SEL)action {
++    UIButton* button = [UIButton buttonWithType:UIButtonTypeSystem];
++    [button setTitle:title forState:UIControlStateNormal];
++    [button setTitleColor:UIColor.whiteColor forState:UIControlStateNormal];
++    button.titleLabel.font = [UIFont systemFontOfSize:14.0 weight:UIFontWeightSemibold];
++    button.backgroundColor = [UIColor colorWithWhite:1.0 alpha:0.14];
++    button.layer.cornerRadius = 10.0;
++    [button addTarget:self action:action forControlEvents:UIControlEventTouchUpInside];
++    return button;
++}
++
++- (void)installLayoutEditor {
++    self.editorPanel = [[UIView alloc] initWithFrame:CGRectZero];
++    self.editorPanel.backgroundColor = [UIColor colorWithWhite:0.04 alpha:0.88];
++    self.editorPanel.layer.borderColor = [UIColor colorWithWhite:1.0 alpha:0.24].CGColor;
++    self.editorPanel.layer.borderWidth = 1.0;
++    self.editorPanel.layer.cornerRadius = 16.0;
++    self.editorPanel.hidden = YES;
++
++    self.editorLabel = [[UILabel alloc] initWithFrame:CGRectZero];
++    self.editorLabel.textColor = UIColor.whiteColor;
++    self.editorLabel.numberOfLines = 2;
++    self.editorLabel.font = [UIFont systemFontOfSize:14.0 weight:UIFontWeightSemibold];
++    [self.editorPanel addSubview:self.editorLabel];
++
++    self.sizeSlider = [[UISlider alloc] initWithFrame:CGRectZero];
++    self.sizeSlider.minimumValue = 0.70f;
++    self.sizeSlider.maximumValue = 1.50f;
++    self.sizeSlider.value = 1.0f;
++    self.sizeSlider.minimumTrackTintColor =
++        [UIColor colorWithRed:0.28 green:0.68 blue:1.0 alpha:1.0];
++    [self.sizeSlider addTarget:self
++                        action:@selector(editorSizeChanged:)
++              forControlEvents:UIControlEventValueChanged];
++    [self.editorPanel addSubview:self.sizeSlider];
++
++    self.visibilityButton =
++        [self editorButtonWithTitle:@"Hide" action:@selector(toggleSelectedVisibility)];
++    self.resetButton =
++        [self editorButtonWithTitle:@"Reset" action:@selector(resetCurrentLayout)];
++    self.doneButton =
++        [self editorButtonWithTitle:@"Done" action:@selector(endLayoutEditing)];
++    self.doneButton.backgroundColor =
++        [UIColor colorWithRed:0.10 green:0.48 blue:0.92 alpha:0.88];
++    self.resetButton.accessibilityIdentifier = @"touch-layout-reset";
++    self.doneButton.accessibilityIdentifier = @"touch-layout-done";
++    [self.editorPanel addSubview:self.visibilityButton];
++    [self.editorPanel addSubview:self.resetButton];
++    [self.editorPanel addSubview:self.doneButton];
++    [self addSubview:self.editorPanel];
++
++    for (UIView* control in self.editableControls) {
++        UIPanGestureRecognizer* pan =
++            [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(moveControl:)];
++        UITapGestureRecognizer* tap =
++            [[UITapGestureRecognizer alloc] initWithTarget:self
++                                                    action:@selector(selectControlGesture:)];
++        pan.enabled = NO;
++        tap.enabled = NO;
++        [control addGestureRecognizer:pan];
++        [control addGestureRecognizer:tap];
++        [self.editGestures addObject:pan];
++        [self.editGestures addObject:tap];
++    }
++}
++
++- (void)layoutEditorPanel {
++    if (self.editorPanel.hidden) {
++        return;
++    }
++    UIEdgeInsets safe = self.safeAreaInsets;
++    CGFloat width = CGRectGetWidth(self.bounds);
++    BOOL compact = CGRectGetHeight(self.bounds) < 560.0;
++    CGFloat panelWidth =
++        MIN(width - safe.left - safe.right - (compact ? 8.0 : 16.0),
++            compact ? 560.0 : 720.0);
++    CGFloat panelHeight = compact ? 50.0 : 86.0;
++    self.editorPanel.frame =
++        CGRectMake(CGRectGetMidX(self.bounds) - panelWidth * 0.5,
++                   safe.top + (compact ? 4.0 : 8.0), panelWidth, panelHeight);
++    self.editorPanel.layer.cornerRadius = compact ? 12.0 : 16.0;
++
++    CGFloat inset = compact ? 5.0 : 12.0;
++    CGFloat buttonWidth = compact ? 54.0 : 70.0;
++    CGFloat gap = compact ? 4.0 : 8.0;
++    CGFloat contentHeight = panelHeight - inset * 2.0;
++    CGFloat trailingButtonsWidth = buttonWidth * 3.0 + gap * 2.0;
++    CGFloat labelWidth = compact ? 94.0 : MIN(150.0, panelWidth * 0.23);
++    CGFloat sliderX = inset + labelWidth + gap;
++    CGFloat sliderWidth =
++        panelWidth - inset * 2.0 - labelWidth - gap - trailingButtonsWidth - gap;
++    self.editorLabel.numberOfLines = compact ? 1 : 2;
++    self.editorLabel.font =
++        [UIFont systemFontOfSize:(compact ? 11.0 : 14.0) weight:UIFontWeightSemibold];
++    self.editorLabel.frame = CGRectMake(inset, inset, labelWidth, contentHeight);
++    self.sizeSlider.frame =
++        CGRectMake(sliderX, inset, MAX(80.0, sliderWidth), contentHeight);
++
++    CGFloat buttonX = panelWidth - inset - trailingButtonsWidth;
++    for (UIButton* button in
++         @[ self.visibilityButton, self.resetButton, self.doneButton ]) {
++        button.titleLabel.font =
++            [UIFont systemFontOfSize:(compact ? 12.0 : 14.0) weight:UIFontWeightSemibold];
++        button.layer.cornerRadius = compact ? 8.0 : 10.0;
++        button.frame = CGRectMake(buttonX, inset, buttonWidth, contentHeight);
++        buttonX += buttonWidth + gap;
++    }
++}
++
++- (NSString*)profileForCompact:(BOOL)compact {
++    return compact ? @"phone-v1" : @"tablet-v1";
++}
++
++- (NSString*)storageKeyForProfile:(NSString*)profile {
++    return [@"HarkinianPad.TouchLayout." stringByAppendingString:profile];
++}
++
++- (void)loadLayoutForProfile:(NSString*)profile {
++    if ([self.layoutProfile isEqualToString:profile]) {
++        return;
++    }
++    self.layoutProfile = profile;
++    [self.layoutCenters removeAllObjects];
++    [self.layoutScales removeAllObjects];
++    [self.hiddenControls removeAllObjects];
++
++    NSDictionary* stored =
++        [NSUserDefaults.standardUserDefaults
++            dictionaryForKey:[self storageKeyForProfile:profile]];
++    NSDictionary* centers = stored[@"centers"];
++    NSDictionary* scales = stored[@"scales"];
++    NSArray* hidden = stored[@"hidden"];
++    if ([centers isKindOfClass:NSDictionary.class]) {
++        [self.layoutCenters addEntriesFromDictionary:centers];
++    }
++    if ([scales isKindOfClass:NSDictionary.class]) {
++        [self.layoutScales addEntriesFromDictionary:scales];
++    }
++    if ([hidden isKindOfClass:NSArray.class]) {
++        [self.hiddenControls addObjectsFromArray:hidden];
++    }
++}
++
++- (void)saveCurrentLayout {
++    if (self.layoutProfile.length == 0) {
++        return;
++    }
++    NSDictionary* stored = @{
++        @"centers": [self.layoutCenters copy],
++        @"scales": [self.layoutScales copy],
++        @"hidden": self.hiddenControls.allObjects,
++    };
++    [NSUserDefaults.standardUserDefaults
++        setObject:stored
++           forKey:[self storageKeyForProfile:self.layoutProfile]];
++}
++
++- (void)clampControlToSafeBounds:(UIView*)control {
++    UIEdgeInsets safe = self.safeAreaInsets;
++    CGFloat halfWidth = CGRectGetWidth(control.bounds) * 0.5;
++    CGFloat halfHeight = CGRectGetHeight(control.bounds) * 0.5;
++    CGFloat minX = safe.left + halfWidth + 4.0;
++    CGFloat maxX = CGRectGetWidth(self.bounds) - safe.right - halfWidth - 4.0;
++    CGFloat minY = safe.top + halfHeight + 4.0;
++    CGFloat maxY = CGRectGetHeight(self.bounds) - safe.bottom - halfHeight - 4.0;
++    control.center = CGPointMake(
++        std::clamp(control.center.x, minX, MAX(minX, maxX)),
++        std::clamp(control.center.y, minY, MAX(minY, maxY)));
++}
++
++- (void)finishControlLayoutForCompact:(BOOL)compact {
++    if (!self.customizableControls) {
++        for (UIView* control in self.editableControls) {
++            control.hidden = NO;
++            control.alpha = 1.0;
++            control.layer.shadowOpacity = 0.0;
++        }
++        [self layoutEditorPanel];
++        return;
++    }
++
++    [self loadLayoutForProfile:[self profileForCompact:compact]];
++    [self.defaultSizes removeAllObjects];
++    CGFloat width = CGRectGetWidth(self.bounds);
++    CGFloat height = CGRectGetHeight(self.bounds);
++    for (UIView* control in self.editableControls) {
++        NSString* key = control.accessibilityIdentifier;
++        if (key.length == 0) {
++            continue;
++        }
++        CGSize defaultSize = control.bounds.size;
++        self.defaultSizes[key] = [NSValue valueWithCGSize:defaultSize];
++        CGFloat scale = self.layoutScales[key] == nil
++            ? 1.0
++            : std::clamp(self.layoutScales[key].doubleValue, 0.70, 1.50);
++        control.bounds =
++            CGRectMake(0.0, 0.0, defaultSize.width * scale, defaultSize.height * scale);
++        NSArray<NSNumber*>* center = self.layoutCenters[key];
++        if ([center isKindOfClass:NSArray.class] && center.count == 2) {
++            control.center =
++                CGPointMake(center[0].doubleValue * width, center[1].doubleValue * height);
++        }
++        [self clampControlToSafeBounds:control];
++        BOOL hidden = [self.hiddenControls containsObject:key];
++        control.hidden = self.layoutEditing ? NO : hidden;
++        control.alpha = self.layoutEditing && hidden ? 0.28 : 1.0;
++        BOOL selected = self.layoutEditing && control == self.selectedControl;
++        control.layer.shadowColor =
++            [UIColor colorWithRed:1.0 green:0.78 blue:0.16 alpha:1.0].CGColor;
++        control.layer.shadowRadius = selected ? 8.0 : 0.0;
++        control.layer.shadowOpacity = selected ? 1.0 : 0.0;
++        control.layer.shadowOffset = CGSizeZero;
++    }
++    [self layoutEditorPanel];
++    [self bringSubviewToFront:self.editorPanel];
++}
++
++- (void)selectControl:(UIView*)control {
++    if (!self.layoutEditing || control == nil) {
++        return;
++    }
++    self.selectedControl = control;
++    NSString* label = control.accessibilityLabel;
++    if (label.length == 0) {
++        label = control.accessibilityIdentifier;
++    }
++    BOOL compact = CGRectGetHeight(self.bounds) < 560.0;
++    self.editorLabel.text =
++        compact ? [NSString stringWithFormat:@"%@ • Drag • Size", label]
++                : [NSString stringWithFormat:@"%@\nDrag to move • Size", label];
++    NSString* key = control.accessibilityIdentifier;
++    self.sizeSlider.value =
++        self.layoutScales[key] == nil ? 1.0f : self.layoutScales[key].floatValue;
++    BOOL hidden = [self.hiddenControls containsObject:key];
++    [self.visibilityButton setTitle:(hidden ? @"Show" : @"Hide")
++                           forState:UIControlStateNormal];
++    self.visibilityButton.enabled = ![key isEqualToString:@"stick"];
++    self.visibilityButton.alpha = self.visibilityButton.enabled ? 1.0 : 0.4;
++    [self setNeedsLayout];
++}
++
++- (void)selectControlGesture:(UITapGestureRecognizer*)gesture {
++    [self selectControl:gesture.view];
++}
++
++- (void)moveControl:(UIPanGestureRecognizer*)gesture {
++    UIView* control = gesture.view;
++    if (!self.layoutEditing || control == nil) {
++        return;
++    }
++    if (gesture.state == UIGestureRecognizerStateBegan) {
++        [self selectControl:control];
++    }
++    CGPoint translation = [gesture translationInView:self];
++    control.center =
++        CGPointMake(control.center.x + translation.x, control.center.y + translation.y);
++    [gesture setTranslation:CGPointZero inView:self];
++    [self clampControlToSafeBounds:control];
++    self.layoutCenters[control.accessibilityIdentifier] = @[
++        @(control.center.x / CGRectGetWidth(self.bounds)),
++        @(control.center.y / CGRectGetHeight(self.bounds)),
++    ];
++}
++
++- (void)editorSizeChanged:(UISlider*)slider {
++    UIView* control = self.selectedControl;
++    NSString* key = control.accessibilityIdentifier;
++    NSValue* sizeValue = self.defaultSizes[key];
++    if (control == nil || key.length == 0 || sizeValue == nil) {
++        return;
++    }
++    CGFloat scale = slider.value;
++    self.layoutScales[key] = @(scale);
++    CGSize baseSize = sizeValue.CGSizeValue;
++    control.bounds =
++        CGRectMake(0.0, 0.0, baseSize.width * scale, baseSize.height * scale);
++    [self clampControlToSafeBounds:control];
++    self.layoutCenters[key] = @[
++        @(control.center.x / CGRectGetWidth(self.bounds)),
++        @(control.center.y / CGRectGetHeight(self.bounds)),
++    ];
++}
++
++- (void)toggleSelectedVisibility {
++    NSString* key = self.selectedControl.accessibilityIdentifier;
++    if (key.length == 0 || [key isEqualToString:@"stick"]) {
++        return;
++    }
++    if ([self.hiddenControls containsObject:key]) {
++        [self.hiddenControls removeObject:key];
++    } else {
++        [self.hiddenControls addObject:key];
++    }
++    [self selectControl:self.selectedControl];
++}
++
++- (void)resetCurrentLayout {
++    if (self.layoutProfile.length == 0) {
++        return;
++    }
++    [self.layoutCenters removeAllObjects];
++    [self.layoutScales removeAllObjects];
++    [self.hiddenControls removeAllObjects];
++    [NSUserDefaults.standardUserDefaults
++        removeObjectForKey:[self storageKeyForProfile:self.layoutProfile]];
++    [self setNeedsLayout];
++    [self selectControl:self.buttonA];
++}
++
++- (void)beginLayoutEditing {
++    if (!self.customizableControls || self.layoutEditing) {
++        return;
++    }
++    [self cancelAllInputs];
++    self.layoutEditing = YES;
++    for (HarkinianPadTouchButton* button in self.buttons) {
++        button.layoutEditing = YES;
++    }
++    self.controlStick.layoutEditing = YES;
++    for (UIGestureRecognizer* gesture in self.editGestures) {
++        gesture.enabled = YES;
++    }
++    self.editorPanel.hidden = NO;
++    sLayoutEditorActive.store(true);
++    sMenuButton.hidden = YES;
++    [self applyNativeHudVisualState];
++    [self selectControl:self.buttonA];
++    [self setNeedsLayout];
++    SDL_Log("[HarkinianPad] touch layout editor opened");
++}
++
++- (void)endLayoutEditing {
++    if (!self.layoutEditing) {
++        return;
++    }
++    [self saveCurrentLayout];
++    self.layoutEditing = NO;
++    for (HarkinianPadTouchButton* button in self.buttons) {
++        button.layoutEditing = NO;
++    }
++    self.controlStick.layoutEditing = NO;
++    for (UIGestureRecognizer* gesture in self.editGestures) {
++        gesture.enabled = NO;
++    }
++    self.editorPanel.hidden = YES;
++    self.selectedControl = nil;
++    sLayoutEditorActive.store(false);
++    sMenuButton.hidden = NO;
++    [self setNeedsLayout];
++    SDL_Log("[HarkinianPad] touch layout saved");
++}
++
+ - (void)publishNativeHudButtonCenters {
+     const CGFloat width = CGRectGetWidth(self.bounds);
+     const CGFloat height = CGRectGetHeight(self.bounds);
+@@ -564,6 +1091,12 @@ static void HarkinianPad_PushKey(SDL_Scancode scancode, BOOL pressed) {
+         self.buttonA, self.buttonB, self.cUp, self.cDown, self.cLeft, self.cRight,
+     ];
+     for (NSUInteger index = 0; index < nativeButtons.count; index++) {
++        if (nativeButtons[index].hidden && !self.layoutEditing) {
++            sNativeHudButtonCenters[index][0].store(0.0f);
++            sNativeHudButtonCenters[index][1].store(0.0f);
++            sNativeHudButtonWidths[index].store(0.0f);
++            continue;
++        }
+         const CGPoint center = nativeButtons[index].center;
+         sNativeHudButtonCenters[index][0].store(center.x / width);
+         sNativeHudButtonCenters[index][1].store(center.y / height);
+@@ -574,7 +1107,8 @@ static void HarkinianPad_PushKey(SDL_Scancode scancode, BOOL pressed) {
+ - (void)applyNativeHudVisualState {
+     const BOOL hideUIKitFaceButtons =
+         sTouchControlsDesired.load() && sNativeHudTouchDesired.load() &&
+-        sNativeHudTouchGameplayActive.load() && !sTouchControlsMenuVisible.load();
++        sNativeHudTouchGameplayActive.load() && !sTouchControlsMenuVisible.load() &&
++        !sLayoutEditorActive.load();
+     for (HarkinianPadTouchButton* button in
+          @[ self.buttonA, self.buttonB, self.cUp, self.cDown, self.cLeft, self.cRight ]) {
+         // Hide only UIKit's artwork. The button itself stays fully opaque and
+@@ -593,7 +1127,7 @@ static void HarkinianPad_PushKey(SDL_Scancode scancode, BOOL pressed) {
+ @end
+ 
+ static HarkinianPadTouchOverlay* sTouchOverlay;
+-static HarkinianPadTouchButton* sMenuButton;
++static BOOL sLifecycleObserversInstalled;
+ 
+ static UIWindow* HarkinianPad_ActiveWindow(void) {
+     for (UIScene* scene in UIApplication.sharedApplication.connectedScenes) {
+@@ -651,6 +1185,25 @@ static void HarkinianPad_InstallMenuButton(UIWindow* window) {
+     [window bringSubviewToFront:sMenuButton];
+ }
+ 
++static void HarkinianPad_InstallLifecycleObservers(void) {
++    if (sLifecycleObserversInstalled) {
++        return;
++    }
++    sLifecycleObserversInstalled = YES;
++    NSNotificationCenter* notifications = NSNotificationCenter.defaultCenter;
++    for (NSNotificationName name in
++         @[ UIApplicationWillResignActiveNotification,
++            UIApplicationDidEnterBackgroundNotification ]) {
++        [notifications addObserverForName:name
++                                   object:nil
++                                    queue:NSOperationQueue.mainQueue
++                               usingBlock:^(NSNotification* notification) {
++                                   (void)notification;
++                                   [sTouchOverlay cancelAllInputs];
++                               }];
++    }
++}
++
+ static void HarkinianPad_ApplyTouchControlsState(void) {
+     UIWindow* window = HarkinianPad_ActiveWindow();
+     if (window == nil) {
+@@ -663,9 +1216,15 @@ static void HarkinianPad_ApplyTouchControlsState(void) {
+ 
+     HarkinianPad_InstallMenuButton(window);
+     if (!sTouchControlsDesired.load() || sTouchControlsMenuVisible.load()) {
++        if (sTouchOverlay.layoutEditing) {
++            [sTouchOverlay endLayoutEditing];
++        }
+         [sTouchOverlay cancelAllInputs];
+         [sTouchOverlay removeFromSuperview];
+         sTouchOverlay = nil;
++        if (!sTouchControlsDesired.load()) {
++            sLayoutEditorRequested = NO;
++        }
+         return;
+     }
+ 
+@@ -673,14 +1232,22 @@ static void HarkinianPad_ApplyTouchControlsState(void) {
+         sTouchOverlay = [[HarkinianPadTouchOverlay alloc] initWithFrame:window.bounds];
+         sTouchOverlay.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+     }
++    [sTouchOverlay
++        setCustomizableControlsEnabled:sCustomizableTouchControlsDesired.load()];
+     if (sTouchOverlay.superview != window) {
+         [sTouchOverlay removeFromSuperview];
+         sTouchOverlay.frame = window.bounds;
+         [window addSubview:sTouchOverlay];
+     }
++    if (sLayoutEditorRequested && sCustomizableTouchControlsDesired.load()) {
++        sLayoutEditorRequested = NO;
++        [sTouchOverlay beginLayoutEditing];
++    }
+     [sTouchOverlay applyNativeHudVisualState];
+     [window bringSubviewToFront:sTouchOverlay];
+-    [window bringSubviewToFront:sMenuButton];
++    if (!sLayoutEditorActive.load()) {
++        [window bringSubviewToFront:sMenuButton];
++    }
+ }
+ 
+ int HarkinianPad_TouchControlsAvailable(void) {
+@@ -689,11 +1256,41 @@ int HarkinianPad_TouchControlsAvailable(void) {
+ 
+ void HarkinianPad_SetTouchControlsEnabled(int enabled) {
+     dispatch_async(dispatch_get_main_queue(), ^{
++        HarkinianPad_InstallLifecycleObservers();
+         sTouchControlsDesired.store(enabled != 0);
+         HarkinianPad_ApplyTouchControlsState();
+     });
+ }
+ 
++void HarkinianPad_SetCustomizableTouchControlsEnabled(int enabled) {
++    dispatch_async(dispatch_get_main_queue(), ^{
++        const BOOL customizable = enabled != 0;
++        sCustomizableTouchControlsDesired.store(customizable);
++        if (!customizable) {
++            sLayoutEditorRequested = NO;
++        }
++        [sTouchOverlay setCustomizableControlsEnabled:customizable];
++        HarkinianPad_ApplyTouchControlsState();
++    });
++}
++
++void HarkinianPad_BeginTouchLayoutEditing(void) {
++    dispatch_async(dispatch_get_main_queue(), ^{
++        if (!sTouchControlsDesired.load() ||
++            !sCustomizableTouchControlsDesired.load()) {
++            SDL_Log("[HarkinianPad] customizable touch controls are disabled");
++            return;
++        }
++        sLayoutEditorRequested = YES;
++        if (sTouchControlsMenuVisible.load()) {
++            HarkinianPad_PushKey(SDL_SCANCODE_ESCAPE, YES);
++            HarkinianPad_PushKey(SDL_SCANCODE_ESCAPE, NO);
++        } else {
++            HarkinianPad_ApplyTouchControlsState();
++        }
++    });
++}
++
+ void HarkinianPad_SetTouchControlsMenuVisible(int visible) {
+     const bool menuVisible = visible != 0;
+     if (sTouchControlsMenuVisible.exchange(menuVisible) == menuVisible) {
+@@ -736,7 +1333,8 @@ void HarkinianPad_SetNativeHudTouchGameplayActive(int active) {
+ int HarkinianPad_GetNativeHudButtonCenter(int button, float aspectRatio, float* x, float* y) {
+     if (button < 0 || button >= HARKINIANPAD_HUD_BUTTON_COUNT || x == nullptr || y == nullptr ||
+         aspectRatio <= 0.0f || !sTouchControlsDesired.load() || !sNativeHudTouchDesired.load() ||
+-        !sNativeHudTouchGameplayActive.load() || sTouchControlsMenuVisible.load()) {
++        !sNativeHudTouchGameplayActive.load() || sTouchControlsMenuVisible.load() ||
++        sLayoutEditorActive.load()) {
+         return 0;
+     }
+ 
+@@ -756,7 +1354,8 @@ int HarkinianPad_GetNativeHudButtonCenter(int button, float aspectRatio, float*
+ float HarkinianPad_GetNativeHudButtonScale(int button, float aspectRatio) {
+     if (button < 0 || button >= HARKINIANPAD_HUD_BUTTON_COUNT || aspectRatio <= 0.0f ||
+         !sTouchControlsDesired.load() || !sNativeHudTouchDesired.load() ||
+-        !sNativeHudTouchGameplayActive.load() || sTouchControlsMenuVisible.load()) {
++        !sNativeHudTouchGameplayActive.load() || sTouchControlsMenuVisible.load() ||
++        sLayoutEditorActive.load()) {
+         return 1.0f;
+     }
+ 
+diff --git a/soh/soh/Enhancements/bootcommands.c b/soh/soh/Enhancements/bootcommands.c
+index 276cfa65d..a7fa63b78 100644
+--- a/soh/soh/Enhancements/bootcommands.c
++++ b/soh/soh/Enhancements/bootcommands.c
+@@ -21,8 +21,12 @@ void BootCommands_Init() {
+     CVarRegisterInteger(CVAR_SETTING("HarkinianPad.TouchControls"), 1);
+     HarkinianPad_SetTouchControlsEnabled(
+         CVarGetInteger(CVAR_SETTING("HarkinianPad.TouchControls"), 1));
+-    CVarRegisterInteger(CVAR_SETTING("HarkinianPad.NativeHudTouch"), 0);
+-    HarkinianPad_SetNativeHudTouchEnabled(
+-        CVarGetInteger(CVAR_SETTING("HarkinianPad.NativeHudTouch"), 0));
++    CVarRegisterInteger(CVAR_SETTING("HarkinianPad.LegacyFixedTouchControls"), 0);
++    const int modernTouchControls =
++        !CVarGetInteger(CVAR_SETTING("HarkinianPad.LegacyFixedTouchControls"), 0);
++    CVarSetInteger(CVAR_SETTING("HarkinianPad.CustomizableTouchControls"), modernTouchControls);
++    CVarSetInteger(CVAR_SETTING("HarkinianPad.NativeHudTouch"), modernTouchControls);
++    HarkinianPad_SetCustomizableTouchControlsEnabled(modernTouchControls);
++    HarkinianPad_SetNativeHudTouchEnabled(modernTouchControls);
+ #endif
+ }
+diff --git a/soh/soh/SohGui/SohMenuSettings.cpp b/soh/soh/SohGui/SohMenuSettings.cpp
+index 8a2039048..c4f3812e9 100644
+--- a/soh/soh/SohGui/SohMenuSettings.cpp
++++ b/soh/soh/SohGui/SohMenuSettings.cpp
+@@ -453,21 +453,42 @@ void SohMenu::AddMenuSettings() {
+         })
+         .Options(CheckboxOptions()
+                      .DefaultValue(true)
+-                     .Tooltip("Shows the low-grip touch controller. Disable it when using a physical controller."));
+-    AddWidget(path, "Native HUD Touch Controls (Experimental)", WIDGET_CVAR_CHECKBOX)
+-        .CVar(CVAR_SETTING("HarkinianPad.NativeHudTouch"))
++                     .Tooltip("Shows the touch controller. Disable it when using a physical controller."));
++    AddWidget(path, "Legacy Fixed Touch Controls", WIDGET_CVAR_CHECKBOX)
++        .CVar(CVAR_SETTING("HarkinianPad.LegacyFixedTouchControls"))
+         .RaceDisable(false)
+         .PreFunc([](WidgetInfo& info) {
+             info.isHidden = !HarkinianPad_TouchControlsAvailable();
+         })
+         .Callback([](WidgetInfo& info) {
+-            HarkinianPad_SetNativeHudTouchEnabled(
+-                CVarGetInteger(CVAR_SETTING("HarkinianPad.NativeHudTouch"), 0));
++            const bool modernTouchControls =
++                !CVarGetInteger(CVAR_SETTING("HarkinianPad.LegacyFixedTouchControls"), 0);
++            CVarSetInteger(CVAR_SETTING("HarkinianPad.CustomizableTouchControls"), modernTouchControls);
++            CVarSetInteger(CVAR_SETTING("HarkinianPad.NativeHudTouch"), modernTouchControls);
++            HarkinianPad_SetCustomizableTouchControlsEnabled(modernTouchControls);
++            HarkinianPad_SetNativeHudTouchEnabled(modernTouchControls);
+         })
+         .Options(CheckboxOptions()
+                      .DefaultValue(false)
+-                     .Tooltip("Experimental: uses the in-game A, B, and C HUD graphics over the existing touch "
+-                              "targets during gameplay. Touch Controls must remain enabled."));
++                     .Tooltip("Uses the previous fixed UIKit layout and disables customization, native HUD "
++                              "artwork, and the Z hold latch."));
++    AddWidget(path, "Customize Touch Layout", WIDGET_BUTTON)
++        .RaceDisable(false)
++        .PreFunc([](WidgetInfo& info) {
++            info.isHidden = !HarkinianPad_TouchControlsAvailable();
++            const bool available =
++                CVarGetInteger(CVAR_SETTING("HarkinianPad.TouchControls"), 1) &&
++                !CVarGetInteger(CVAR_SETTING("HarkinianPad.LegacyFixedTouchControls"), 0);
++            info.options->disabled = !available;
++            info.options->disabledTooltip =
++                "Enable Touch Controls and turn off Legacy Fixed Touch Controls first.";
++        })
++        .Callback([](WidgetInfo& info) {
++            HarkinianPad_BeginTouchLayoutEditing();
++        })
++        .Options(ButtonOptions().Tooltip(
++            "Closes Settings and opens the layout editor. Drag controls, resize the selected control, hide "
++            "unused buttons, or restore the phone or tablet defaults."));
+ #endif
+     AddWidget(path, "Clear Devices", WIDGET_BUTTON)
+         .Callback([](WidgetInfo& info) {

--- a/scripts/apply-source-patches.sh
+++ b/scripts/apply-source-patches.sh
@@ -54,17 +54,29 @@ fi
 apply_patch "$SHIPWRIGHT" \
     "$ROOT/patches/shipwright-ios-app-icon.patch"
 
-# The experiment layers on the stable touch patch and changes some of the same
-# files. Detect the final state first so rerunning remains idempotent.
+# The customizable controller layers on the stable touch and native-HUD
+# patches and changes some of the same files. Detect the final state first so rerunning remains
+# idempotent.
 if git -C "$SHIPWRIGHT" apply --reverse --check \
-    "$ROOT/patches/shipwright-ios-native-hud-touch-experiment.patch" 2>/dev/null; then
+    "$ROOT/patches/shipwright-ios-customizable-touch-controls.patch" \
+    2>/dev/null; then
     echo "Already applied: shipwright-ios-touch-controls.patch"
     echo "Already applied: shipwright-ios-native-hud-touch-experiment.patch"
+    echo "Already applied: shipwright-ios-customizable-touch-controls.patch"
 else
+    if git -C "$SHIPWRIGHT" apply --reverse --check \
+        "$ROOT/patches/shipwright-ios-native-hud-touch-experiment.patch" \
+        2>/dev/null; then
+        echo "Already applied: shipwright-ios-touch-controls.patch"
+        echo "Already applied: shipwright-ios-native-hud-touch-experiment.patch"
+    else
+        apply_patch "$SHIPWRIGHT" \
+            "$ROOT/patches/shipwright-ios-touch-controls.patch"
+        apply_patch "$SHIPWRIGHT" \
+            "$ROOT/patches/shipwright-ios-native-hud-touch-experiment.patch"
+    fi
     apply_patch "$SHIPWRIGHT" \
-        "$ROOT/patches/shipwright-ios-touch-controls.patch"
-    apply_patch "$SHIPWRIGHT" \
-        "$ROOT/patches/shipwright-ios-native-hud-touch-experiment.patch"
+        "$ROOT/patches/shipwright-ios-customizable-touch-controls.patch"
 fi
 
 APP_ICON_SOURCE="$ROOT/assets/AppIcon.appiconset"


### PR DESCRIPTION
## Summary

- make the physically accepted customizable controller the default on iPhone and iPad
- embed the accepted phone and tablet layouts as the clean-install and Reset defaults
- compact the iPhone layout editor, preserve the Z hold latch, and expose the previous fixed UIKit controller as `Legacy Fixed Touch Controls`
- update the maintained Shipwright patch, patch application flow, README, and touch-control documentation

## User impact

New installs use the native-HUD customizable controls by default. Existing saved phone and tablet profiles continue to apply. Users can still opt into the previous fixed UIKit controls from Settings.

## Validation

- arm64 signed iPhoneOS Release build succeeded
- strict `codesign --verify --deep --strict` passed for the exact app bundle
- the same signed build installed in place and launched on physical iPhone 14 and iPad Pro 12.9-inch
- both device preference files remained byte-identical after installation
- user physically accepted the iPhone and iPad layouts and touch behavior
- maintained patch reverse-check and idempotent reapplication passed
- `bash -n scripts/apply-source-patches.sh`
- `scripts/check-repo-safety.sh`
