### PR TITLE
Add touch-control transparency settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ HarkinianPad selects a landscape layout for the current device class:
   controls are disabled.
 - **Toggle:** use **Settings → Controls → Touch Controls** to hide or restore
   the gameplay overlay.
+- **Transparency:** enable **Touch Control Transparency** to reveal a 25%–100%
+  opacity slider. This is off by default and does not change touch targets.
 - **Customize:** choose **Customize Touch Layout** to move, resize, or hide
   controls in separate phone and tablet layouts.
 - **Fallback:** enable **Legacy Fixed Touch Controls** to use the previous

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -223,12 +223,17 @@ Confirm that:
    input viewer.
 2. Disabling **Touch Controls** removes the overlay immediately; enabling it
    restores the overlay without restarting.
-3. Confirm the native A/B/C graphics move with their touch targets during
+3. Enable **Touch Control Transparency**, confirm the opacity slider appears,
+   and test 25%, 50%, and 100%. The UIKit controls and gameplay-native A/B/C
+   artwork should change together while their touch targets remain unchanged.
+   Confirm the value persists after relaunch and the layout editor remains
+   fully opaque.
+4. Confirm the native A/B/C graphics move with their touch targets during
    gameplay—including the compact iPhone arrangement—and the visible UIKit
    buttons return on title, file-select, and pause screens.
-4. Opening the menu hides every gameplay control, and closing it restores the
+5. Opening the menu hides every gameplay control, and closing it restores the
    overlay only when **Touch Controls** is enabled.
-5. Open **Customize Touch Layout** and confirm the editor can select, move,
+6. Open **Customize Touch Layout** and confirm the editor can select, move,
    resize, hide/show, reset, and save controls without
    changing the other device class's profile. Confirm the stick cannot be
    hidden and `•••` returns after Done. In gameplay, hold Z for 0.5 seconds:
@@ -237,11 +242,11 @@ Confirm that:
    opening the menu or backgrounding the app clears the latch. Enable
    **Legacy Fixed Touch Controls** and confirm the previous fixed UIKit layout
    returns and the editor is unavailable.
-6. A save can be created or selected and Link can be controlled in active
+7. A save can be created or selected and Link can be controlled in active
    gameplay for at least ten minutes.
-7. Disconnecting and reconnecting the controller does not crash the app and
+8. Disconnecting and reconnecting the controller does not crash the app and
    restores control without losing the current save.
-8. Rumble and motion input are recorded as supported, unsupported, or not
+9. Rumble and motion input are recorded as supported, unsupported, or not
    exposed for the exact controller model; do not infer either capability
    from the extended-gamepad declaration.
 

--- a/docs/customizable-touch-controls.md
+++ b/docs/customizable-touch-controls.md
@@ -25,6 +25,11 @@ The control stick cannot be hidden, and the permanent `•••` menu control i
 not editable. Starting the editor releases held input and temporarily disables
 the controls' normal gameplay handlers.
 
+**Touch Control Transparency** under **Settings > Controls** reveals a
+25%–100% **Touch Control Opacity** slider. The option is off by default, and
+the layout editor temporarily restores full opacity without changing the saved
+preference or any touch target.
+
 ## Persistence and layout rules
 
 Phone and tablet layouts are stored separately in `NSUserDefaults`:

--- a/docs/touch-control-transparency.md
+++ b/docs/touch-control-transparency.md
@@ -1,0 +1,30 @@
+# Touch-control transparency feasibility
+
+## Verdict
+
+Feasible with a small, low-risk implementation. HarkinianPad already owns the
+UIKit touch overlay, the native A/B/C artwork bridge, and persisted Settings
+widgets, so opacity can change without changing control frames, hit testing,
+bindings, or saved layouts.
+
+## Implementation
+
+- **Touch Control Transparency** is default-off, preserving the accepted
+  appearance on existing and clean installations.
+- Enabling it reveals **Touch Control Opacity**, a persisted 25%–100% slider
+  with a 50% default.
+- UIKit controls and the permanent menu button use the selected opacity.
+- Native gameplay A/B/C artwork and its labels, icons, and ammo counts use the
+  same opacity. The regular HUD is unchanged when native touch artwork is not
+  active.
+- The layout editor temporarily shows controls at full opacity so selection,
+  hiding, and resizing remain clear.
+- Opacity never changes view visibility, frames, gesture recognizers, or input
+  handling.
+
+## Validation gate
+
+Before release, verify default-off parity, both slider extremes, persistence
+after relaunch, unchanged hit targets, the full-opacity layout editor, native
+A/B/C artwork in gameplay, and both modern and legacy layouts on Simulator and
+physical iPad hardware.

--- a/patches/shipwright-ios-touch-control-transparency.patch
+++ b/patches/shipwright-ios-touch-control-transparency.patch
@@ -1,0 +1,399 @@
+diff --git a/soh/ios/HarkinianPadTouchControls.h b/soh/ios/HarkinianPadTouchControls.h
+index 493db1607..af26545c9 100644
+--- a/soh/ios/HarkinianPadTouchControls.h
++++ b/soh/ios/HarkinianPadTouchControls.h
+@@ -7,6 +7,7 @@ extern "C" {
+ int HarkinianPad_TouchControlsAvailable(void);
+ void HarkinianPad_SetTouchControlsEnabled(int enabled);
+ void HarkinianPad_SetCustomizableTouchControlsEnabled(int enabled);
++void HarkinianPad_SetTouchControlsOpacity(float opacity);
+ void HarkinianPad_BeginTouchLayoutEditing(void);
+ void HarkinianPad_SetTouchControlsMenuVisible(int visible);
+ 
+@@ -24,6 +25,7 @@ void HarkinianPad_SetNativeHudTouchEnabled(int enabled);
+ void HarkinianPad_SetNativeHudTouchGameplayActive(int active);
+ int HarkinianPad_GetNativeHudButtonCenter(int button, float aspectRatio, float* x, float* y);
+ float HarkinianPad_GetNativeHudButtonScale(int button, float aspectRatio);
++int HarkinianPad_GetNativeHudTouchAlpha(int alpha);
+ 
+ #ifdef __cplusplus
+ }
+diff --git a/soh/ios/HarkinianPadTouchControls.mm b/soh/ios/HarkinianPadTouchControls.mm
+index 954e06329..690a7ceaa 100644
+--- a/soh/ios/HarkinianPadTouchControls.mm
++++ b/soh/ios/HarkinianPadTouchControls.mm
+@@ -8,6 +8,7 @@
+ 
+ static std::atomic_bool sTouchControlsDesired(false);
+ static std::atomic_bool sCustomizableTouchControlsDesired(false);
++static std::atomic<float> sTouchControlsOpacity(1.0f);
+ static std::atomic_bool sTouchControlsMenuVisible(false);
+ static std::atomic_bool sLayoutEditorActive(false);
+ static BOOL sLayoutEditorRequested;
+@@ -373,6 +374,7 @@ static HarkinianPadTouchButton* sMenuButton;
+ @property(nonatomic, strong) HarkinianPadTouchButton* cRight;
+ @property(nonatomic) BOOL customizableControls;
+ @property(nonatomic) BOOL layoutEditing;
++@property(nonatomic) CGFloat touchControlsOpacity;
+ @property(nonatomic, strong) NSArray<UIView*>* editableControls;
+ @property(nonatomic, strong) NSMutableArray<UIGestureRecognizer*>* editGestures;
+ @property(nonatomic, strong) NSMutableDictionary<NSString*, NSArray<NSNumber*>*>* layoutCenters;
+@@ -390,6 +392,7 @@ static HarkinianPadTouchButton* sMenuButton;
+ 
+ - (void)cancelAllInputs;
+ - (void)setCustomizableControlsEnabled:(BOOL)enabled;
++- (void)setTouchControlsOpacity:(CGFloat)opacity;
+ - (void)beginLayoutEditing;
+ - (void)endLayoutEditing;
+ - (void)installLayoutEditor;
+@@ -494,6 +497,7 @@ static HarkinianPadTouchButton* sMenuButton;
+         self.hiddenControls = [NSMutableSet set];
+         self.defaultSizes = [NSMutableDictionary dictionary];
+         self.editGestures = [NSMutableArray array];
++        self.touchControlsOpacity = 1.0;
+ 
+         [self addSubview:self.controlStick];
+         for (HarkinianPadTouchButton* button in self.buttons) {
+@@ -728,6 +732,11 @@ static HarkinianPadTouchButton* sMenuButton;
+     [self setNeedsLayout];
+ }
+ 
++- (void)setTouchControlsOpacity:(CGFloat)opacity {
++    _touchControlsOpacity = std::clamp(opacity, 0.25, 1.0);
++    [self setNeedsLayout];
++}
++
+ - (UIButton*)editorButtonWithTitle:(NSString*)title action:(SEL)action {
+     UIButton* button = [UIButton buttonWithType:UIButtonTypeSystem];
+     [button setTitle:title forState:UIControlStateNormal];
+@@ -902,7 +911,7 @@ static HarkinianPadTouchButton* sMenuButton;
+     if (!self.customizableControls) {
+         for (UIView* control in self.editableControls) {
+             control.hidden = NO;
+-            control.alpha = 1.0;
++            control.alpha = self.touchControlsOpacity;
+             control.layer.shadowOpacity = 0.0;
+         }
+         [self layoutEditorPanel];
+@@ -933,7 +942,7 @@ static HarkinianPadTouchButton* sMenuButton;
+         [self clampControlToSafeBounds:control];
+         BOOL hidden = [self.hiddenControls containsObject:key];
+         control.hidden = self.layoutEditing ? NO : hidden;
+-        control.alpha = self.layoutEditing && hidden ? 0.28 : 1.0;
++        control.alpha = self.layoutEditing ? (hidden ? 0.28 : 1.0) : self.touchControlsOpacity;
+         BOOL selected = self.layoutEditing && control == self.selectedControl;
+         control.layer.shadowColor =
+             [UIColor colorWithRed:1.0 green:0.78 blue:0.16 alpha:1.0].CGColor;
+@@ -1182,6 +1191,7 @@ static void HarkinianPad_InstallMenuButton(UIWindow* window) {
+         [sMenuButton removeFromSuperview];
+         [window addSubview:sMenuButton];
+     }
++    sMenuButton.alpha = sTouchControlsOpacity.load();
+     [window bringSubviewToFront:sMenuButton];
+ }
+ 
+@@ -1234,6 +1244,7 @@ static void HarkinianPad_ApplyTouchControlsState(void) {
+     }
+     [sTouchOverlay
+         setCustomizableControlsEnabled:sCustomizableTouchControlsDesired.load()];
++    [sTouchOverlay setTouchControlsOpacity:sTouchControlsOpacity.load()];
+     if (sTouchOverlay.superview != window) {
+         [sTouchOverlay removeFromSuperview];
+         sTouchOverlay.frame = window.bounds;
+@@ -1274,6 +1285,18 @@ void HarkinianPad_SetCustomizableTouchControlsEnabled(int enabled) {
+     });
+ }
+ 
++void HarkinianPad_SetTouchControlsOpacity(float opacity) {
++    const float clampedOpacity = std::clamp(opacity, 0.25f, 1.0f);
++    sTouchControlsOpacity.store(clampedOpacity);
++    dispatch_async(dispatch_get_main_queue(), ^{
++        [sTouchOverlay setTouchControlsOpacity:clampedOpacity];
++        UIWindow* window = HarkinianPad_ActiveWindow();
++        if (window != nil) {
++            HarkinianPad_InstallMenuButton(window);
++        }
++    });
++}
++
+ void HarkinianPad_BeginTouchLayoutEditing(void) {
+     dispatch_async(dispatch_get_main_queue(), ^{
+         if (!sTouchControlsDesired.load() ||
+@@ -1372,3 +1395,14 @@ float HarkinianPad_GetNativeHudButtonScale(int button, float aspectRatio) {
+     const float virtualWidth = normalizedWidth * 240.0f;
+     return virtualWidth / nativeButtonWidths[button];
+ }
++
++int HarkinianPad_GetNativeHudTouchAlpha(int alpha) {
++    const bool nativeTouchArtworkVisible =
++        sTouchControlsDesired.load() && sNativeHudTouchDesired.load() &&
++        sNativeHudTouchGameplayActive.load() && !sTouchControlsMenuVisible.load() &&
++        !sLayoutEditorActive.load();
++    if (!nativeTouchArtworkVisible) {
++        return std::clamp(alpha, 0, 255);
++    }
++    return std::clamp(static_cast<int>(alpha * sTouchControlsOpacity.load() + 0.5f), 0, 255);
++}
+diff --git a/soh/soh/Enhancements/bootcommands.c b/soh/soh/Enhancements/bootcommands.c
+index a7fa63b78..576a8c33d 100644
+--- a/soh/soh/Enhancements/bootcommands.c
++++ b/soh/soh/Enhancements/bootcommands.c
+@@ -21,6 +21,12 @@ void BootCommands_Init() {
+     CVarRegisterInteger(CVAR_SETTING("HarkinianPad.TouchControls"), 1);
+     HarkinianPad_SetTouchControlsEnabled(
+         CVarGetInteger(CVAR_SETTING("HarkinianPad.TouchControls"), 1));
++    CVarRegisterInteger(CVAR_SETTING("HarkinianPad.TouchControlTransparency"), 0);
++    CVarRegisterFloat(CVAR_SETTING("HarkinianPad.TouchControlOpacity"), 0.5f);
++    HarkinianPad_SetTouchControlsOpacity(
++        CVarGetInteger(CVAR_SETTING("HarkinianPad.TouchControlTransparency"), 0)
++            ? CVarGetFloat(CVAR_SETTING("HarkinianPad.TouchControlOpacity"), 0.5f)
++            : 1.0f);
+     CVarRegisterInteger(CVAR_SETTING("HarkinianPad.LegacyFixedTouchControls"), 0);
+     const int modernTouchControls =
+         !CVarGetInteger(CVAR_SETTING("HarkinianPad.LegacyFixedTouchControls"), 0);
+diff --git a/soh/soh/SohGui/SohMenuSettings.cpp b/soh/soh/SohGui/SohMenuSettings.cpp
+index c4f3812e9..9345eef06 100644
+--- a/soh/soh/SohGui/SohMenuSettings.cpp
++++ b/soh/soh/SohGui/SohMenuSettings.cpp
+@@ -454,6 +454,39 @@ void SohMenu::AddMenuSettings() {
+         .Options(CheckboxOptions()
+                      .DefaultValue(true)
+                      .Tooltip("Shows the touch controller. Disable it when using a physical controller."));
++    AddWidget(path, "Touch Control Transparency", WIDGET_CVAR_CHECKBOX)
++        .CVar(CVAR_SETTING("HarkinianPad.TouchControlTransparency"))
++        .RaceDisable(false)
++        .PreFunc([](WidgetInfo& info) {
++            info.isHidden = !HarkinianPad_TouchControlsAvailable();
++        })
++        .Callback([](WidgetInfo& info) {
++            const bool enabled =
++                CVarGetInteger(CVAR_SETTING("HarkinianPad.TouchControlTransparency"), 0);
++            HarkinianPad_SetTouchControlsOpacity(
++                enabled ? CVarGetFloat(CVAR_SETTING("HarkinianPad.TouchControlOpacity"), 0.5f) : 1.0f);
++        })
++        .Options(CheckboxOptions()
++                     .DefaultValue(false)
++                     .Tooltip("Allows the touch controls to use the opacity selected below. Input areas are "
++                              "unchanged."));
++    AddWidget(path, "Touch Control Opacity", WIDGET_CVAR_SLIDER_FLOAT)
++        .CVar(CVAR_SETTING("HarkinianPad.TouchControlOpacity"))
++        .RaceDisable(false)
++        .PreFunc([](WidgetInfo& info) {
++            info.isHidden = !HarkinianPad_TouchControlsAvailable() ||
++                            !CVarGetInteger(CVAR_SETTING("HarkinianPad.TouchControlTransparency"), 0);
++        })
++        .Callback([](WidgetInfo& info) {
++            HarkinianPad_SetTouchControlsOpacity(
++                CVarGetFloat(CVAR_SETTING("HarkinianPad.TouchControlOpacity"), 0.5f));
++        })
++        .Options(FloatSliderOptions()
++                     .IsPercentage()
++                     .Min(0.25f)
++                     .Max(1.0f)
++                     .DefaultValue(0.5f)
++                     .Tooltip("Sets touch-control opacity. Lower values show more of the game beneath them."));
+     AddWidget(path, "Legacy Fixed Touch Controls", WIDGET_CVAR_CHECKBOX)
+         .CVar(CVAR_SETTING("HarkinianPad.LegacyFixedTouchControls"))
+         .RaceDisable(false)
+diff --git a/soh/src/code/z_parameter.c b/soh/src/code/z_parameter.c
+index cc5b81de7..bd7e6e4bd 100644
+--- a/soh/src/code/z_parameter.c
++++ b/soh/src/code/z_parameter.c
+@@ -23,6 +23,9 @@
+ 
+ #ifdef __IOS__
+ #include "ios/HarkinianPadTouchControls.h"
++#define HARKINIANPAD_TOUCH_ALPHA(alpha) HarkinianPad_GetNativeHudTouchAlpha(alpha)
++#else
++#define HARKINIANPAD_TOUCH_ALPHA(alpha) (alpha)
+ #endif
+ #include "soh/Enhancements/gameplaystats.h"
+ #include "soh/ObjectExtension/ActorMaximumHealth.h"
+@@ -4213,7 +4216,8 @@ void Interface_DrawItemButtons(PlayState* play) {
+     // Also loads the Item Button Texture reused by other buttons afterwards
+     gDPPipeSync(OVERLAY_DISP++);
+     gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
+-    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, bButtonColor.r, bButtonColor.g, bButtonColor.b, interfaceCtx->bAlpha);
++    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, bButtonColor.r, bButtonColor.g, bButtonColor.b,
++                    HARKINIANPAD_TOUCH_ALPHA(interfaceCtx->bAlpha));
+     gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 255);
+ 
+     OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, gButtonBackgroundTex, BBtn_Size, BBtn_Size, PosX_BtnB, PosY_BtnB,
+@@ -4222,7 +4226,7 @@ void Interface_DrawItemButtons(PlayState* play) {
+     // C-Left Button Color & Texture
+     gDPPipeSync(OVERLAY_DISP++);
+     gDPSetPrimColor(OVERLAY_DISP++, 0, 0, cLeftButtonColor.r, cLeftButtonColor.g, cLeftButtonColor.b,
+-                    interfaceCtx->cLeftAlpha);
++                    HARKINIANPAD_TOUCH_ALPHA(interfaceCtx->cLeftAlpha));
+     gSPWideTextureRectangle(OVERLAY_DISP++, C_Left_BTN_Pos[0] << 2, C_Left_BTN_Pos[1] << 2,
+                             (C_Left_BTN_Pos[0] + CLeftDrawSize) << 2,
+                             (C_Left_BTN_Pos[1] + CLeftDrawSize) << 2, G_TX_RENDERTILE, 0, 0,
+@@ -4230,7 +4234,7 @@ void Interface_DrawItemButtons(PlayState* play) {
+ 
+     // C-Down Button Color & Texture
+     gDPSetPrimColor(OVERLAY_DISP++, 0, 0, cDownButtonColor.r, cDownButtonColor.g, cDownButtonColor.b,
+-                    interfaceCtx->cDownAlpha);
++                    HARKINIANPAD_TOUCH_ALPHA(interfaceCtx->cDownAlpha));
+     gSPWideTextureRectangle(OVERLAY_DISP++, C_Down_BTN_Pos[0] << 2, C_Down_BTN_Pos[1] << 2,
+                             (C_Down_BTN_Pos[0] + CDownDrawSize) << 2,
+                             (C_Down_BTN_Pos[1] + CDownDrawSize) << 2, G_TX_RENDERTILE, 0, 0,
+@@ -4238,7 +4242,7 @@ void Interface_DrawItemButtons(PlayState* play) {
+ 
+     // C-Right Button Color & Texture
+     gDPSetPrimColor(OVERLAY_DISP++, 0, 0, cRightButtonColor.r, cRightButtonColor.g, cRightButtonColor.b,
+-                    interfaceCtx->cRightAlpha);
++                    HARKINIANPAD_TOUCH_ALPHA(interfaceCtx->cRightAlpha));
+     gSPWideTextureRectangle(OVERLAY_DISP++, C_Right_BTN_Pos[0] << 2, C_Right_BTN_Pos[1] << 2,
+                             (C_Right_BTN_Pos[0] + CRightDrawSize) << 2,
+                             (C_Right_BTN_Pos[1] + CRightDrawSize) << 2, G_TX_RENDERTILE, 0, 0,
+@@ -4298,14 +4302,15 @@ void Interface_DrawItemButtons(PlayState* play) {
+                 temp = interfaceCtx->healthAlpha;
+             }
+ 
+-            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, cUpButtonColor.r, cUpButtonColor.g, cUpButtonColor.b, temp);
++            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, cUpButtonColor.r, cUpButtonColor.g, cUpButtonColor.b,
++                            HARKINIANPAD_TOUCH_ALPHA(temp));
+             gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
+             gSPWideTextureRectangle(OVERLAY_DISP++, C_Up_BTN_Pos[0] << 2, C_Up_BTN_Pos[1] << 2,
+                                     (C_Up_BTN_Pos[0] + CUpScaled) << 2,
+                                     (C_Up_BTN_Pos[1] + CUpScaled) << 2, G_TX_RENDERTILE, 0, 0,
+                                     CUp_factor, CUp_factor);
+             gDPPipeSync(OVERLAY_DISP++);
+-            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, temp);
++            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, HARKINIANPAD_TOUCH_ALPHA(temp));
+             gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 0);
+             gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
+                               PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
+@@ -4471,13 +4476,13 @@ void Interface_DrawItemButtons(PlayState* play) {
+ 
+             if (temp == 1) {
+                 gDPSetPrimColor(OVERLAY_DISP++, 0, 0, cLeftButtonColor.r, cLeftButtonColor.g, cLeftButtonColor.b,
+-                                interfaceCtx->cLeftAlpha);
++                                HARKINIANPAD_TOUCH_ALPHA(interfaceCtx->cLeftAlpha));
+             } else if (temp == 2) {
+                 gDPSetPrimColor(OVERLAY_DISP++, 0, 0, cDownButtonColor.r, cDownButtonColor.g, cDownButtonColor.b,
+-                                interfaceCtx->cDownAlpha);
++                                HARKINIANPAD_TOUCH_ALPHA(interfaceCtx->cDownAlpha));
+             } else {
+                 gDPSetPrimColor(OVERLAY_DISP++, 0, 0, cRightButtonColor.r, cRightButtonColor.g, cRightButtonColor.b,
+-                                interfaceCtx->cRightAlpha);
++                                HARKINIANPAD_TOUCH_ALPHA(interfaceCtx->cRightAlpha));
+             }
+ 
+             OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, ((u8*)gButtonBackgroundTex), 32, 32, ItemIconPos[temp - 1][0],
+@@ -4568,9 +4573,14 @@ void Interface_DrawItemIconTexture(PlayState* play, void* texture, s16 button) {
+                                         { DPAD_DOWN_X + X_Margins_DPad_Items, DPAD_DOWN_Y + Y_Margins_DPad_Items },
+                                         { DPAD_LEFT_X + X_Margins_DPad_Items, DPAD_LEFT_Y + Y_Margins_DPad_Items },
+                                         { DPAD_RIGHT_X + X_Margins_DPad_Items, DPAD_RIGHT_Y + Y_Margins_DPad_Items } };
+-    u16 ItemsSlotsAlpha[8] = { interfaceCtx->bAlpha,        interfaceCtx->cLeftAlpha,    interfaceCtx->cRightAlpha,
+-                               interfaceCtx->cDownAlpha,    interfaceCtx->dpadUpAlpha,   interfaceCtx->dpadDownAlpha,
+-                               interfaceCtx->dpadLeftAlpha, interfaceCtx->dpadRightAlpha };
++    u16 ItemsSlotsAlpha[8] = { HARKINIANPAD_TOUCH_ALPHA(interfaceCtx->bAlpha),
++                               HARKINIANPAD_TOUCH_ALPHA(interfaceCtx->cLeftAlpha),
++                               HARKINIANPAD_TOUCH_ALPHA(interfaceCtx->cRightAlpha),
++                               HARKINIANPAD_TOUCH_ALPHA(interfaceCtx->cDownAlpha),
++                               interfaceCtx->dpadUpAlpha,
++                               interfaceCtx->dpadDownAlpha,
++                               interfaceCtx->dpadLeftAlpha,
++                               interfaceCtx->dpadRightAlpha };
+     s16 DPad_ItemsOffset[4][2] = {
+         { 7, -8 },         // Up
+         { 7, 24 },         // Down
+@@ -5582,7 +5592,8 @@ void Interface_Draw(PlayState* play) {
+         }
+ 
+         gDPPipeSync(OVERLAY_DISP++);
+-        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->bAlpha);
++        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255,
++                        HARKINIANPAD_TOUCH_ALPHA(interfaceCtx->bAlpha));
+         gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATERGBA_PRIM, G_CC_MODULATERGBA_PRIM);
+ 
+         if (!(interfaceCtx->unk_1FA)) {
+@@ -5602,7 +5613,7 @@ void Interface_Draw(PlayState* play) {
+                     gDPPipeSync(OVERLAY_DISP++);
+                     gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE,
+                                       0, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
+-                    Interface_DrawAmmoCount(play, 0, interfaceCtx->bAlpha);
++                    Interface_DrawAmmoCount(play, 0, HARKINIANPAD_TOUCH_ALPHA(interfaceCtx->bAlpha));
+                 }
+             }
+         } else {
+@@ -5668,7 +5679,8 @@ void Interface_Draw(PlayState* play) {
+             gDPPipeSync(OVERLAY_DISP++);
+             gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
+                               PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
+-            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->bAlpha);
++            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255,
++                            HARKINIANPAD_TOUCH_ALPHA(interfaceCtx->bAlpha));
+ 
+             gDPLoadTextureBlock_4b(OVERLAY_DISP++, interfaceCtx->doActionSegment[1], G_IM_FMT_IA, DO_ACTION_TEX_WIDTH(),
+                                    DO_ACTION_TEX_HEIGHT(), 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
+@@ -5684,39 +5696,42 @@ void Interface_Draw(PlayState* play) {
+ 
+         // C-Left Button Icon & Ammo Count
+         if (gSaveContext.equips.buttonItems[1] < 0xF0) {
+-            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->cLeftAlpha);
++            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255,
++                            HARKINIANPAD_TOUCH_ALPHA(interfaceCtx->cLeftAlpha));
+             gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATERGBA_PRIM, G_CC_MODULATERGBA_PRIM);
+             Interface_DrawItemIconTexture(play, gItemIcons[gSaveContext.equips.buttonItems[1]], 1);
+             gDPPipeSync(OVERLAY_DISP++);
+             gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
+                               PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
+-            Interface_DrawAmmoCount(play, 1, interfaceCtx->cLeftAlpha);
++            Interface_DrawAmmoCount(play, 1, HARKINIANPAD_TOUCH_ALPHA(interfaceCtx->cLeftAlpha));
+         }
+ 
+         gDPPipeSync(OVERLAY_DISP++);
+ 
+         // C-Down Button Icon & Ammo Count
+         if (gSaveContext.equips.buttonItems[2] < 0xF0) {
+-            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->cDownAlpha);
++            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255,
++                            HARKINIANPAD_TOUCH_ALPHA(interfaceCtx->cDownAlpha));
+             gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATERGBA_PRIM, G_CC_MODULATERGBA_PRIM);
+             Interface_DrawItemIconTexture(play, gItemIcons[gSaveContext.equips.buttonItems[2]], 2);
+             gDPPipeSync(OVERLAY_DISP++);
+             gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
+                               PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
+-            Interface_DrawAmmoCount(play, 2, interfaceCtx->cDownAlpha);
++            Interface_DrawAmmoCount(play, 2, HARKINIANPAD_TOUCH_ALPHA(interfaceCtx->cDownAlpha));
+         }
+ 
+         gDPPipeSync(OVERLAY_DISP++);
+ 
+         // C-Right Button Icon & Ammo Count
+         if (gSaveContext.equips.buttonItems[3] < 0xF0) {
+-            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->cRightAlpha);
++            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255,
++                            HARKINIANPAD_TOUCH_ALPHA(interfaceCtx->cRightAlpha));
+             gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATERGBA_PRIM, G_CC_MODULATERGBA_PRIM);
+             Interface_DrawItemIconTexture(play, gItemIcons[gSaveContext.equips.buttonItems[3]], 3);
+             gDPPipeSync(OVERLAY_DISP++);
+             gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
+                               PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
+-            Interface_DrawAmmoCount(play, 3, interfaceCtx->cRightAlpha);
++            Interface_DrawAmmoCount(play, 3, HARKINIANPAD_TOUCH_ALPHA(interfaceCtx->cRightAlpha));
+         }
+ 
+         if (CVarGetInteger(CVAR_ENHANCEMENT("DpadEquips"), 0) != 0) {
+@@ -5890,7 +5905,8 @@ void Interface_Draw(PlayState* play) {
+ #endif
+         gSPClearGeometryMode(OVERLAY_DISP++, G_CULL_BOTH);
+         gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
+-        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, aButtonColor.r, aButtonColor.g, aButtonColor.b, interfaceCtx->aAlpha);
++        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, aButtonColor.r, aButtonColor.g, aButtonColor.b,
++                        HARKINIANPAD_TOUCH_ALPHA(interfaceCtx->aAlpha));
+         if (fullUi) {
+             Interface_DrawActionButton(play, PosX_BtnA, PosY_BtnA);
+         }
+@@ -5898,7 +5914,8 @@ void Interface_Draw(PlayState* play) {
+         gSPSetGeometryMode(OVERLAY_DISP++, G_CULL_BACK);
+         gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
+                           PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
+-        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->aAlpha);
++        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255,
++                        HARKINIANPAD_TOUCH_ALPHA(interfaceCtx->aAlpha));
+         gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 0);
+         Matrix_Translate(-138.0f + rAIconX, rAIconY, WREG(46 + languageOffset) / 10.0f, MTXMODE_NEW);
+         Matrix_Scale(nativeHudButtonScale, nativeHudButtonScale, nativeHudButtonScale, MTXMODE_APPLY);

--- a/scripts/apply-source-patches.sh
+++ b/scripts/apply-source-patches.sh
@@ -54,29 +54,42 @@ fi
 apply_patch "$SHIPWRIGHT" \
     "$ROOT/patches/shipwright-ios-app-icon.patch"
 
-# The customizable controller layers on the stable touch and native-HUD
-# patches and changes some of the same files. Detect the final state first so rerunning remains
+# The transparency patch is the final controller layer and overlaps the
+# customizable patch. Detect that final state first so rerunning remains
 # idempotent.
 if git -C "$SHIPWRIGHT" apply --reverse --check \
-    "$ROOT/patches/shipwright-ios-customizable-touch-controls.patch" \
+    "$ROOT/patches/shipwright-ios-touch-control-transparency.patch" \
     2>/dev/null; then
     echo "Already applied: shipwright-ios-touch-controls.patch"
     echo "Already applied: shipwright-ios-native-hud-touch-experiment.patch"
     echo "Already applied: shipwright-ios-customizable-touch-controls.patch"
+    echo "Already applied: shipwright-ios-touch-control-transparency.patch"
 else
+    # The customizable controller layers on the stable touch and native-HUD
+    # patches and changes some of the same files.
     if git -C "$SHIPWRIGHT" apply --reverse --check \
-        "$ROOT/patches/shipwright-ios-native-hud-touch-experiment.patch" \
+        "$ROOT/patches/shipwright-ios-customizable-touch-controls.patch" \
         2>/dev/null; then
         echo "Already applied: shipwright-ios-touch-controls.patch"
         echo "Already applied: shipwright-ios-native-hud-touch-experiment.patch"
+        echo "Already applied: shipwright-ios-customizable-touch-controls.patch"
     else
+        if git -C "$SHIPWRIGHT" apply --reverse --check \
+            "$ROOT/patches/shipwright-ios-native-hud-touch-experiment.patch" \
+            2>/dev/null; then
+            echo "Already applied: shipwright-ios-touch-controls.patch"
+            echo "Already applied: shipwright-ios-native-hud-touch-experiment.patch"
+        else
+            apply_patch "$SHIPWRIGHT" \
+                "$ROOT/patches/shipwright-ios-touch-controls.patch"
+            apply_patch "$SHIPWRIGHT" \
+                "$ROOT/patches/shipwright-ios-native-hud-touch-experiment.patch"
+        fi
         apply_patch "$SHIPWRIGHT" \
-            "$ROOT/patches/shipwright-ios-touch-controls.patch"
-        apply_patch "$SHIPWRIGHT" \
-            "$ROOT/patches/shipwright-ios-native-hud-touch-experiment.patch"
+            "$ROOT/patches/shipwright-ios-customizable-touch-controls.patch"
     fi
     apply_patch "$SHIPWRIGHT" \
-        "$ROOT/patches/shipwright-ios-customizable-touch-controls.patch"
+        "$ROOT/patches/shipwright-ios-touch-control-transparency.patch"
 fi
 
 APP_ICON_SOURCE="$ROOT/assets/AppIcon.appiconset"


### PR DESCRIPTION
## Summary

- add a default-off touch-control transparency toggle
- reveal a persistent 25%-100% opacity slider when enabled
- apply opacity to UIKit controls and native gameplay A/B/C artwork without changing touch targets
- keep the layout editor fully opaque and document the behavior
- add the maintained Shipwright patch and patch-replay ordering

## User impact

Players can reduce touch-control opacity to see more of the game while preserving the existing default appearance and input layout.

## Validation

- `git diff --check` for source and documentation files
- `./scripts/check-repo-safety.sh`
- `./scripts/apply-source-patches.sh` idempotence
- transparency patch reverse-check against the built source tree
- `cmake --build build-ios-soh-sim --target soh --config Release`
- iPad Simulator checks at 25%, 50%, and 100%
- verified input, full-opacity editor behavior, native HUD opacity, and persistence after relaunch

Physical iPad comfort validation remains separate from the merged implementation.
